### PR TITLE
Update tests for MCP refactor

### DIFF
--- a/src/services/mcp/__tests__/McpConverters.test.ts
+++ b/src/services/mcp/__tests__/McpConverters.test.ts
@@ -1,6 +1,6 @@
-import { McpConverters } from '../McpConverters';
+import { McpConverters } from '../core/McpConverters';
 import { ToolDefinition } from '../types/McpProviderTypes';
-import { NeutralToolUseRequest, NeutralToolResult } from '../UnifiedMcpToolSystem';
+import { NeutralToolUseRequest, NeutralToolResult } from '../types/McpToolTypes';
 
 // Mock the json-xml-bridge utilities
 jest.mock('../../../utils/json-xml-bridge', () => ({

--- a/src/services/mcp/__tests__/McpIntegration.test.ts
+++ b/src/services/mcp/__tests__/McpIntegration.test.ts
@@ -1,9 +1,9 @@
 import { McpIntegration, handleToolUse } from '../McpIntegration';
-import { McpToolRouter } from '../McpToolRouter';
-import { UnifiedMcpToolSystem } from '../UnifiedMcpToolSystem';
+import { McpToolRouter } from '../core/McpToolRouter';
+import { McpToolExecutor } from '../core/McpToolExecutor';
 
 // Mock the McpToolRouter
-jest.mock('../McpToolRouter', () => {
+jest.mock('../core/McpToolRouter', () => {
   const mockInstance = {
     on: jest.fn(),
     initialize: jest.fn().mockResolvedValue(undefined),
@@ -30,8 +30,8 @@ jest.mock('../McpToolRouter', () => {
   };
 });
 
-// Mock the UnifiedMcpToolSystem
-jest.mock('../UnifiedMcpToolSystem', () => {
+// Mock the McpToolExecutor
+jest.mock('../core/McpToolExecutor', () => {
   const mockInstance = {
     registerTool: jest.fn(),
     unregisterTool: jest.fn().mockReturnValue(true),
@@ -50,7 +50,7 @@ jest.mock('../UnifiedMcpToolSystem', () => {
   };
   
   return {
-    UnifiedMcpToolSystem: {
+    McpToolExecutor: {
       getInstance: jest.fn().mockReturnValue(mockInstance)
     }
   };

--- a/src/services/mcp/__tests__/McpToolRegistry.test.ts
+++ b/src/services/mcp/__tests__/McpToolRegistry.test.ts
@@ -1,4 +1,4 @@
-import { McpToolRegistry } from '../McpToolRegistry';
+import { McpToolRegistry } from '../core/McpToolRegistry';
 import { ToolDefinition } from '../types/McpProviderTypes';
 
 describe('McpToolRegistry', () => {

--- a/src/services/mcp/__tests__/UnifiedMcpToolSystem.test.ts
+++ b/src/services/mcp/__tests__/UnifiedMcpToolSystem.test.ts
@@ -1,8 +1,9 @@
-import { UnifiedMcpToolSystem, NeutralToolUseRequest, NeutralToolResult } from '../UnifiedMcpToolSystem';
-import { McpConverters } from '../McpConverters';
-import { McpToolRouter, ToolUseFormat } from '../McpToolRouter';
+import { McpToolExecutor } from '../core/McpToolExecutor';
+import { NeutralToolUseRequest, NeutralToolResult, ToolUseFormat } from '../types/McpToolTypes';
+import { McpConverters } from '../core/McpConverters';
+import { McpToolRouter } from '../core/McpToolRouter';
 import { EmbeddedMcpProvider } from '../providers/EmbeddedMcpProvider';
-import { McpToolRegistry } from '../McpToolRegistry';
+import { McpToolRegistry } from '../core/McpToolRegistry';
 
 // Mock the EmbeddedMcpProvider
 jest.mock('../providers/EmbeddedMcpProvider', () => {
@@ -52,8 +53,8 @@ jest.mock('../McpToolRegistry', () => {
   };
 });
 
-describe('UnifiedMcpToolSystem', () => {
-  let mcpToolSystem: UnifiedMcpToolSystem;
+describe('McpToolExecutor', () => {
+  let mcpToolSystem: McpToolExecutor;
   
   beforeEach(() => {
     // Clear all mocks
@@ -61,8 +62,8 @@ describe('UnifiedMcpToolSystem', () => {
     
     // Get a fresh instance for each test
     // @ts-ignore - Reset the singleton instance
-    UnifiedMcpToolSystem['instance'] = undefined;
-    mcpToolSystem = UnifiedMcpToolSystem.getInstance();
+    (McpToolExecutor as any).instance = undefined;
+    mcpToolSystem = McpToolExecutor.getInstance();
   });
   
   describe('initialization', () => {
@@ -345,7 +346,7 @@ describe('McpToolRouter', () => {
     });
     
     it('should route XML tool use requests', async () => {
-      // Mock the UnifiedMcpToolSystem's executeToolFromNeutralFormat method
+      // Mock the McpToolExecutor's executeToolFromNeutralFormat method
       const mockExecute = jest.fn().mockResolvedValue({
         type: 'tool_result',
         tool_use_id: 'test-123',
@@ -371,7 +372,7 @@ describe('McpToolRouter', () => {
     });
     
     it('should route JSON tool use requests', async () => {
-      // Mock the UnifiedMcpToolSystem's executeToolFromNeutralFormat method
+      // Mock the McpToolExecutor's executeToolFromNeutralFormat method
       const mockExecute = jest.fn().mockResolvedValue({
         type: 'tool_result',
         tool_use_id: 'test-123',
@@ -404,7 +405,7 @@ describe('McpToolRouter', () => {
     });
     
     it('should handle errors in tool routing', async () => {
-      // Mock the UnifiedMcpToolSystem's executeToolFromNeutralFormat method to throw an error
+      // Mock the McpToolExecutor's executeToolFromNeutralFormat method to throw an error
       const mockExecute = jest.fn().mockRejectedValue(new Error('Test error'));
       
       // @ts-ignore - Replace the method

--- a/src/services/mcp/__tests__/ollama-mcp-integration.test.ts
+++ b/src/services/mcp/__tests__/ollama-mcp-integration.test.ts
@@ -1,7 +1,7 @@
 import { Client } from '@modelcontextprotocol/sdk/client';
 import { McpIntegration } from '../McpIntegration';
 import { SseClientFactory } from '../client/SseClientFactory';
-import { McpConverters } from '../McpConverters';
+import { McpConverters } from '../core/McpConverters';
 
 // Mock the OpenAI client
 jest.mock('openai', () => {


### PR DESCRIPTION
## Summary
- update test imports to use new MCP core modules
- ensure mocked modules match current architecture

## Testing
- `npm test` *(fails: jest not found)*