### PR TITLE
Implement MCP provider and transport abstractions

### DIFF
--- a/src/services/mcp/__tests__/McpConverters.test.ts
+++ b/src/services/mcp/__tests__/McpConverters.test.ts
@@ -1,6 +1,6 @@
-import { McpConverters } from '../McpConverters';
+import { McpConverters } from '../core/McpConverters';
 import { ToolDefinition } from '../types/McpProviderTypes';
-import { NeutralToolUseRequest, NeutralToolResult } from '../UnifiedMcpToolSystem';
+import { NeutralToolUseRequest, NeutralToolResult } from '../types/McpToolTypes';
 
 // Mock the json-xml-bridge utilities
 jest.mock('../../../utils/json-xml-bridge', () => ({

--- a/src/services/mcp/__tests__/McpIntegration.test.ts
+++ b/src/services/mcp/__tests__/McpIntegration.test.ts
@@ -1,9 +1,9 @@
 import { McpIntegration, handleToolUse } from '../McpIntegration';
-import { McpToolRouter } from '../McpToolRouter';
-import { UnifiedMcpToolSystem } from '../UnifiedMcpToolSystem';
+import { McpToolRouter } from '../core/McpToolRouter';
+import { McpToolExecutor } from '../core/McpToolExecutor';
 
 // Mock the McpToolRouter
-jest.mock('../McpToolRouter', () => {
+jest.mock('../core/McpToolRouter', () => {
   const mockInstance = {
     on: jest.fn(),
     initialize: jest.fn().mockResolvedValue(undefined),
@@ -30,8 +30,8 @@ jest.mock('../McpToolRouter', () => {
   };
 });
 
-// Mock the UnifiedMcpToolSystem
-jest.mock('../UnifiedMcpToolSystem', () => {
+// Mock the McpToolExecutor
+jest.mock('../core/McpToolExecutor', () => {
   const mockInstance = {
     registerTool: jest.fn(),
     unregisterTool: jest.fn().mockReturnValue(true),
@@ -50,7 +50,7 @@ jest.mock('../UnifiedMcpToolSystem', () => {
   };
   
   return {
-    UnifiedMcpToolSystem: {
+    McpToolExecutor: {
       getInstance: jest.fn().mockReturnValue(mockInstance)
     }
   };

--- a/src/services/mcp/__tests__/McpToolRegistry.test.ts
+++ b/src/services/mcp/__tests__/McpToolRegistry.test.ts
@@ -1,4 +1,4 @@
-import { McpToolRegistry } from '../McpToolRegistry';
+import { McpToolRegistry } from '../core/McpToolRegistry';
 import { ToolDefinition } from '../types/McpProviderTypes';
 
 describe('McpToolRegistry', () => {

--- a/src/services/mcp/__tests__/UnifiedMcpToolSystem.test.ts
+++ b/src/services/mcp/__tests__/UnifiedMcpToolSystem.test.ts
@@ -1,8 +1,9 @@
-import { UnifiedMcpToolSystem, NeutralToolUseRequest, NeutralToolResult } from '../UnifiedMcpToolSystem';
-import { McpConverters } from '../McpConverters';
-import { McpToolRouter, ToolUseFormat } from '../McpToolRouter';
+import { McpToolExecutor } from '../core/McpToolExecutor';
+import { NeutralToolUseRequest, NeutralToolResult, ToolUseFormat } from '../types/McpToolTypes';
+import { McpConverters } from '../core/McpConverters';
+import { McpToolRouter } from '../core/McpToolRouter';
 import { EmbeddedMcpProvider } from '../providers/EmbeddedMcpProvider';
-import { McpToolRegistry } from '../McpToolRegistry';
+import { McpToolRegistry } from '../core/McpToolRegistry';
 
 // Mock the EmbeddedMcpProvider
 jest.mock('../providers/EmbeddedMcpProvider', () => {
@@ -52,8 +53,8 @@ jest.mock('../McpToolRegistry', () => {
   };
 });
 
-describe('UnifiedMcpToolSystem', () => {
-  let mcpToolSystem: UnifiedMcpToolSystem;
+describe('McpToolExecutor', () => {
+  let mcpToolSystem: McpToolExecutor;
   
   beforeEach(() => {
     // Clear all mocks
@@ -61,8 +62,8 @@ describe('UnifiedMcpToolSystem', () => {
     
     // Get a fresh instance for each test
     // @ts-ignore - Reset the singleton instance
-    UnifiedMcpToolSystem['instance'] = undefined;
-    mcpToolSystem = UnifiedMcpToolSystem.getInstance();
+    (McpToolExecutor as any).instance = undefined;
+    mcpToolSystem = McpToolExecutor.getInstance();
   });
   
   describe('initialization', () => {
@@ -345,7 +346,7 @@ describe('McpToolRouter', () => {
     });
     
     it('should route XML tool use requests', async () => {
-      // Mock the UnifiedMcpToolSystem's executeToolFromNeutralFormat method
+      // Mock the McpToolExecutor's executeToolFromNeutralFormat method
       const mockExecute = jest.fn().mockResolvedValue({
         type: 'tool_result',
         tool_use_id: 'test-123',
@@ -371,7 +372,7 @@ describe('McpToolRouter', () => {
     });
     
     it('should route JSON tool use requests', async () => {
-      // Mock the UnifiedMcpToolSystem's executeToolFromNeutralFormat method
+      // Mock the McpToolExecutor's executeToolFromNeutralFormat method
       const mockExecute = jest.fn().mockResolvedValue({
         type: 'tool_result',
         tool_use_id: 'test-123',
@@ -404,7 +405,7 @@ describe('McpToolRouter', () => {
     });
     
     it('should handle errors in tool routing', async () => {
-      // Mock the UnifiedMcpToolSystem's executeToolFromNeutralFormat method to throw an error
+      // Mock the McpToolExecutor's executeToolFromNeutralFormat method to throw an error
       const mockExecute = jest.fn().mockRejectedValue(new Error('Test error'));
       
       // @ts-ignore - Replace the method

--- a/src/services/mcp/__tests__/ollama-mcp-integration.test.ts
+++ b/src/services/mcp/__tests__/ollama-mcp-integration.test.ts
@@ -1,7 +1,7 @@
 import { Client } from '@modelcontextprotocol/sdk/client';
 import { McpIntegration } from '../McpIntegration';
 import { SseClientFactory } from '../client/SseClientFactory';
-import { McpConverters } from '../McpConverters';
+import { McpConverters } from '../core/McpConverters';
 
 // Mock the OpenAI client
 jest.mock('openai', () => {

--- a/src/services/mcp/providers/MockMcpProvider.ts
+++ b/src/services/mcp/providers/MockMcpProvider.ts
@@ -1,0 +1,78 @@
+import { EventEmitter } from "events";
+import {
+  ToolCallResult,
+  ToolDefinition,
+  IMcpProvider,
+} from "../types/McpProviderTypes";
+
+/**
+ * MockMcpProvider provides a mock implementation of the MCP provider for testing.
+ */
+export class MockMcpProvider extends EventEmitter implements IMcpProvider {
+  private tools: Map<string, ToolDefinition> = new Map();
+  private isStarted = false;
+  private serverUrl?: URL;
+
+  constructor() {
+    super();
+  }
+
+  async start(): Promise<void> {
+    if (this.isStarted) {
+      return;
+    }
+    this.isStarted = true;
+    this.serverUrl = new URL("http://localhost:0");
+    this.emit("started", { url: this.serverUrl.toString() });
+  }
+
+  async stop(): Promise<void> {
+    if (!this.isStarted) {
+      return;
+    }
+    this.isStarted = false;
+    this.serverUrl = undefined;
+    this.emit("stopped");
+  }
+
+  registerToolDefinition(definition: ToolDefinition): void {
+    this.tools.set(definition.name, definition);
+    this.emit("tool-registered", definition.name);
+  }
+
+  unregisterTool(name: string): boolean {
+    const result = this.tools.delete(name);
+    if (result) {
+      this.emit("tool-unregistered", name);
+    }
+    return result;
+  }
+
+  async executeTool(name: string, args: Record<string, unknown>): Promise<ToolCallResult> {
+    const tool = this.tools.get(name);
+    if (!tool) {
+      return {
+        content: [{ type: "text", text: `Tool '${name}' not found` }],
+        isError: true,
+      };
+    }
+    try {
+      return await tool.handler(args || {});
+    } catch (error) {
+      return {
+        content: [
+          { type: "text", text: `Error executing tool '${name}': ${error instanceof Error ? error.message : String(error)}` },
+        ],
+        isError: true,
+      };
+    }
+  }
+
+  getServerUrl(): URL | undefined {
+    return this.serverUrl;
+  }
+
+  isRunning(): boolean {
+    return this.isStarted;
+  }
+}

--- a/src/services/mcp/providers/RemoteMcpProvider.ts
+++ b/src/services/mcp/providers/RemoteMcpProvider.ts
@@ -1,0 +1,90 @@
+import { EventEmitter } from "events";
+import {
+  ToolCallResult,
+  ToolDefinition,
+  IMcpProvider,
+} from "../types/McpProviderTypes";
+import { SseClientFactory } from "../client/SseClientFactory";
+
+/**
+ * RemoteMcpProvider provides a provider for connecting to external MCP servers.
+ */
+export class RemoteMcpProvider extends EventEmitter implements IMcpProvider {
+  private tools: Map<string, ToolDefinition> = new Map();
+  private isStarted = false;
+  private serverUrl?: URL;
+  private client?: any;
+
+  constructor(private readonly url: URL) {
+    super();
+    this.serverUrl = url;
+  }
+
+  async start(): Promise<void> {
+    if (this.isStarted) {
+      return;
+    }
+    try {
+      this.client = await SseClientFactory.createClient(this.serverUrl!);
+      this.isStarted = true;
+      this.emit("started", { url: this.serverUrl!.toString() });
+    } catch (error) {
+      throw new Error(`Failed to connect to remote MCP server: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (!this.isStarted) {
+      return;
+    }
+    try {
+      if (this.client) {
+        await this.client.close();
+      }
+    } catch (error) {
+      console.error("Error stopping remote MCP client:", error);
+    } finally {
+      this.client = undefined;
+      this.isStarted = false;
+      this.emit("stopped");
+    }
+  }
+
+  registerToolDefinition(definition: ToolDefinition): void {
+    this.tools.set(definition.name, definition);
+    this.emit("tool-registered", definition.name);
+  }
+
+  unregisterTool(name: string): boolean {
+    const result = this.tools.delete(name);
+    if (result) {
+      this.emit("tool-unregistered", name);
+    }
+    return result;
+  }
+
+  async executeTool(name: string, args: Record<string, unknown>): Promise<ToolCallResult> {
+    if (!this.isStarted || !this.client) {
+      throw new Error("Remote MCP provider not started");
+    }
+    try {
+      const result = await this.client.callTool({ name, arguments: args });
+      return { content: result.content, isError: result.status === "error" };
+    } catch (error) {
+      return {
+        content: [
+          { type: "text", text: `Error executing tool '${name}': ${error instanceof Error ? error.message : String(error)}` },
+        ],
+        isError: true,
+      };
+    }
+  }
+
+  getServerUrl(): URL | undefined {
+    return this.serverUrl;
+  }
+
+  isRunning(): boolean {
+    return this.isStarted;
+  }
+}

--- a/src/services/mcp/transport/SseTransport.ts
+++ b/src/services/mcp/transport/SseTransport.ts
@@ -1,0 +1,71 @@
+import { IMcpTransport } from "../types/McpTransportTypes";
+import { SseTransportConfig, DEFAULT_SSE_CONFIG } from "./config/SseTransportConfig";
+
+/**
+ * Mock implementation of the SSEServerTransport for type compatibility
+ * This will be replaced with the actual implementation when the MCP SDK is installed
+ */
+class MockSseServerTransport {
+  constructor(_options?: any) {}
+  getPort(): number {
+    return 0;
+  }
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
+  onerror?: (error: Error) => void;
+  onclose?: () => void;
+}
+
+/**
+ * SseTransport provides an implementation of the MCP transport using SSE.
+ */
+export class SseTransport implements IMcpTransport {
+  private transport: any;
+  private config: SseTransportConfig;
+
+  constructor(config?: SseTransportConfig) {
+    this.config = { ...DEFAULT_SSE_CONFIG, ...config };
+
+    try {
+      const { SSEServerTransport } = require("@modelcontextprotocol/sdk/server/sse.js");
+      this.transport = new SSEServerTransport({
+        port: this.config.port,
+        hostname: this.config.hostname,
+        cors: this.config.allowExternalConnections ? { origin: "*" } : { origin: "localhost" },
+        eventsPath: this.config.eventsPath,
+        apiPath: this.config.apiPath,
+      });
+    } catch {
+      console.warn("MCP SDK not found, using mock implementation");
+      this.transport = new MockSseServerTransport();
+    }
+  }
+
+  async start(): Promise<void> {
+    // SSE transport does not require explicit start
+    return Promise.resolve();
+  }
+
+  async close(): Promise<void> {
+    if (this.transport && typeof this.transport.close === "function") {
+      await this.transport.close();
+    }
+  }
+
+  getPort(): number {
+    return this.transport.getPort();
+  }
+
+  set onerror(handler: (error: Error) => void) {
+    if (this.transport) {
+      this.transport.onerror = handler;
+    }
+  }
+
+  set onclose(handler: () => void) {
+    if (this.transport) {
+      this.transport.onclose = handler;
+    }
+  }
+}

--- a/src/services/mcp/transport/StdioTransport.ts
+++ b/src/services/mcp/transport/StdioTransport.ts
@@ -1,0 +1,80 @@
+import { IMcpTransport } from "../types/McpTransportTypes";
+import { StdioTransportConfig } from "../types/McpTransportTypes";
+
+/**
+ * Mock implementation of the StdioServerTransport for type compatibility
+ * This will be replaced with the actual implementation when the MCP SDK is installed
+ */
+class MockStdioServerTransport {
+  constructor() {}
+  start(): Promise<void> {
+    return Promise.resolve();
+  }
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
+  get stderr(): any {
+    return undefined;
+  }
+  onerror?: (error: Error) => void;
+  onclose?: () => void;
+}
+
+/**
+ * StdioTransport provides an implementation of the MCP transport using stdio.
+ */
+export class StdioTransport implements IMcpTransport {
+  private transport: any;
+  private _stderr?: any;
+
+  constructor(options: StdioTransportConfig) {
+    try {
+      const { StdioServerTransport } = require("@modelcontextprotocol/sdk/server/stdio.js");
+      this.transport = new StdioServerTransport({
+        command: options.command,
+        args: options.args,
+        env: {
+          ...options.env,
+          ...(process.env.PATH ? { PATH: process.env.PATH } : {}),
+        },
+        stderr: "pipe",
+      });
+    } catch {
+      console.warn("MCP SDK not found, using mock implementation");
+      this.transport = new MockStdioServerTransport();
+    }
+  }
+
+  async start(): Promise<void> {
+    if (this.transport && typeof this.transport.start === "function") {
+      await this.transport.start();
+      this._stderr = this.transport.stderr;
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.transport && typeof this.transport.close === "function") {
+      await this.transport.close();
+    }
+  }
+
+  getPort(): number | undefined {
+    return undefined;
+  }
+
+  get stderr(): any {
+    return this._stderr;
+  }
+
+  set onerror(handler: (error: Error) => void) {
+    if (this.transport) {
+      this.transport.onerror = handler;
+    }
+  }
+
+  set onclose(handler: () => void) {
+    if (this.transport) {
+      this.transport.onclose = handler;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `SseTransport` and `StdioTransport` classes
- add `MockMcpProvider` and `RemoteMcpProvider`
- refactor `EmbeddedMcpProvider` to delegate to transports
- update types and constructors to support transport selection

## Testing
- `npm run test:types` *(fails: cannot find name 'process', missing node/vscode types)*
- `npm test` *(fails: jest not found)*