### PR TITLE
Update MCP docs with new class names

### DIFF
--- a/cline_docs/architectural_notes/tool_use/mcp/README.md
+++ b/cline_docs/architectural_notes/tool_use/mcp/README.md
@@ -24,9 +24,9 @@ The documentation is organized into several documents, each focusing on a specif
 
 The MCP implementation in Thea Code consists of several key components:
 
-- **EmbeddedMcpServer**: A server implementation that runs in the same process as the client
+- **EmbeddedMcpProvider**: A server implementation that runs in the same process as the client
 - **McpToolRegistry**: A registry of tools that can be called by the server
-- **UnifiedMcpToolSystem**: A system that manages tools from multiple sources
+- **McpToolExecutor**: A system that manages tools from multiple sources
 - **McpIntegration**: A class that integrates MCP with the rest of the system
 - **McpConverters**: A class that converts between different tool formats
 - **McpToolRouter**: A class that routes tool use requests to the appropriate handler

--- a/cline_docs/architectural_notes/tool_use/mcp/mcp_integration_architecture_diagram.md
+++ b/cline_docs/architectural_notes/tool_use/mcp/mcp_integration_architecture_diagram.md
@@ -41,12 +41,12 @@ graph TD
     subgraph "MCP Integration"
         MI[McpIntegration]
         MTR[McpToolRouter]
-        UMTS[UnifiedMcpToolSystem]
+        UMTS[McpToolExecutor]
         MC[McpConverters]
     end
     
     subgraph "MCP Server"
-        EMCP[EmbeddedMcpServer]
+        EMCP[EmbeddedMcpProvider]
         MTReg[McpToolRegistry]
     end
     
@@ -133,7 +133,7 @@ sequenceDiagram
     participant TP as TheaProvider
     participant PH as Provider Handler
     participant MI as McpIntegration
-    participant EMCP as EmbeddedMcpServer
+    participant EMCP as EmbeddedMcpProvider
     participant TE as Tool Executor
     
     User->>WA: User input
@@ -170,15 +170,15 @@ sequenceDiagram
 
 - Detects the format of tool use requests
 - Routes requests to the appropriate converter
-- Executes tools through the UnifiedMcpToolSystem
+- Executes tools through the McpToolExecutor
 
-### 5.3 UnifiedMcpToolSystem
+### 5.3 McpToolExecutor
 
 - Provides a unified interface for tool use
 - Manages the embedded MCP server
 - Executes tools and processes results
 
-### 5.4 EmbeddedMcpServer
+### 5.4 EmbeddedMcpProvider
 
 - Hosts tools from various sources
 - Provides a standardized interface for tool execution

--- a/cline_docs/architectural_notes/tool_use/mcp/mcp_integration_implementation.md
+++ b/cline_docs/architectural_notes/tool_use/mcp/mcp_integration_implementation.md
@@ -12,9 +12,9 @@ The MCP integration provides a unified tool system for handling tool use across 
 
 1. **McpIntegration**: A facade that provides a simple interface for the rest of the application
 2. **McpToolRouter**: Detects format and routes tool use requests to appropriate handlers
-3. **UnifiedMcpToolSystem**: Core component for tool use across different AI models
+3. **McpToolExecutor**: Core component for tool use across different AI models
 4. **McpConverters**: Utility functions for converting between different formats and MCP protocol
-5. **EmbeddedMcpServer**: Hosts tools from various sources
+5. **EmbeddedMcpProvider**: Hosts tools from various sources
 6. **McpToolRegistry**: Central registry for all tools in the system
 
 ### 1.2 Integration Flow
@@ -25,8 +25,8 @@ sequenceDiagram
     participant MI as McpIntegration
     participant MTR as McpToolRouter
     participant MC as McpConverters
-    participant UMTS as UnifiedMcpToolSystem
-    participant EMCP as EmbeddedMcpServer
+    participant UMTS as McpToolExecutor
+    participant EMCP as EmbeddedMcpProvider
     participant MTReg as McpToolRegistry
     
     PH->>MI: Initialize MCP integration
@@ -301,16 +301,16 @@ The `McpIntegration` class serves as a facade for the MCP system:
 // src/services/mcp/McpIntegration.ts
 
 import { McpToolRouter } from './McpToolRouter';
-import { UnifiedMcpToolSystem } from './UnifiedMcpToolSystem';
+import { McpToolExecutor } from './McpToolExecutor';
 import { ToolDefinition } from './types';
 
 export class McpIntegration {
   private mcpToolRouter: McpToolRouter;
-  private mcpToolSystem: UnifiedMcpToolSystem;
+  private mcpToolSystem: McpToolExecutor;
   private isInitialized: boolean = false;
   
   constructor() {
-    this.mcpToolSystem = new UnifiedMcpToolSystem();
+    this.mcpToolSystem = new McpToolExecutor();
     this.mcpToolRouter = new McpToolRouter(this.mcpToolSystem);
   }
   
@@ -349,16 +349,16 @@ The `McpToolRouter` class detects the format and routes tool use requests:
 ```typescript
 // src/services/mcp/McpToolRouter.ts
 
-import { UnifiedMcpToolSystem } from './UnifiedMcpToolSystem';
+import { McpToolExecutor } from './McpToolExecutor';
 import { McpConverters } from './McpConverters';
 import { FormatDetector } from '../../utils/json-xml-bridge';
 import { NeutralToolUseRequest, NeutralToolResult } from './types';
 
 export class McpToolRouter {
-  private mcpToolSystem: UnifiedMcpToolSystem;
+  private mcpToolSystem: McpToolExecutor;
   private formatDetector: FormatDetector;
   
-  constructor(mcpToolSystem: UnifiedMcpToolSystem) {
+  constructor(mcpToolSystem: McpToolExecutor) {
     this.mcpToolSystem = mcpToolSystem;
     this.formatDetector = new FormatDetector();
   }
@@ -426,25 +426,25 @@ export class McpToolRouter {
 }
 ```
 
-### 3.3 UnifiedMcpToolSystem
+### 3.3 McpToolExecutor
 
-The `UnifiedMcpToolSystem` class provides a unified interface for tool use:
+The `McpToolExecutor` class provides a unified interface for tool use:
 
 ```typescript
-// src/services/mcp/UnifiedMcpToolSystem.ts
+// src/services/mcp/McpToolExecutor.ts
 
-import { EmbeddedMcpServer } from './EmbeddedMcpServer';
+import { EmbeddedMcpProvider } from './EmbeddedMcpProvider';
 import { McpToolRegistry } from './McpToolRegistry';
 import { ToolDefinition, NeutralToolUseRequest, NeutralToolResult } from './types';
 
-export class UnifiedMcpToolSystem {
-  private mcpServer: EmbeddedMcpServer;
+export class McpToolExecutor {
+  private mcpServer: EmbeddedMcpProvider;
   private toolRegistry: McpToolRegistry;
   private isInitialized: boolean = false;
   
   constructor() {
     this.toolRegistry = new McpToolRegistry();
-    this.mcpServer = new EmbeddedMcpServer(this.toolRegistry);
+    this.mcpServer = new EmbeddedMcpProvider(this.toolRegistry);
   }
   
   async initialize(): Promise<void> {

--- a/cline_docs/architectural_notes/tool_use/mcp/mcp_refactoring_implementation_details.md
+++ b/cline_docs/architectural_notes/tool_use/mcp/mcp_refactoring_implementation_details.md
@@ -437,14 +437,14 @@ export class EmbeddedMcpProvider extends EventEmitter implements IMcpProvider {
       // Try to import the MCP SDK dynamically
       const { McpServer } = require("@modelcontextprotocol/sdk/server/mcp.js");
       this.server = new McpServer({
-        name: "EmbeddedMcpServer",
+        name: "EmbeddedMcpProvider",
         version: "1.0.0"
       });
     } catch (error) {
       // If the MCP SDK is not installed, use the mock implementation
       console.warn("MCP SDK not found, using mock implementation");
       this.server = new MockMcpServer({
-        name: "EmbeddedMcpServer",
+        name: "EmbeddedMcpProvider",
         version: "1.0.0"
       });
     }

--- a/cline_docs/architectural_notes/tool_use/mcp/mcp_refactoring_plan.md
+++ b/cline_docs/architectural_notes/tool_use/mcp/mcp_refactoring_plan.md
@@ -39,7 +39,7 @@ classDiagram
         -executeTool()
     }
     
-    class UnifiedMcpToolSystem {
+    class McpToolExecutor {
         +initialize()
         +shutdown()
         +registerTool()
@@ -51,7 +51,7 @@ classDiagram
         -convertToolResultToXml()
     }
     
-    class EmbeddedMcpServer {
+    class EmbeddedMcpProvider {
         +start()
         +stop()
         +registerToolDefinition()
@@ -124,13 +124,13 @@ classDiagram
     }
     
     McpIntegration --> McpToolRouter : uses
-    McpIntegration --> UnifiedMcpToolSystem : uses
-    McpToolRouter --> UnifiedMcpToolSystem : uses
+    McpIntegration --> McpToolExecutor : uses
+    McpToolRouter --> McpToolExecutor : uses
     McpToolRouter --> McpConverters : uses
-    UnifiedMcpToolSystem --> EmbeddedMcpServer : uses
-    UnifiedMcpToolSystem --> McpToolRegistry : uses
-    UnifiedMcpToolSystem --> McpConverters : uses
-    EmbeddedMcpServer --> SseTransportConfig : uses
+    McpToolExecutor --> EmbeddedMcpProvider : uses
+    McpToolExecutor --> McpToolRegistry : uses
+    McpToolExecutor --> McpConverters : uses
+    EmbeddedMcpProvider --> SseTransportConfig : uses
     McpHub --> SseClientFactory : uses
     McpServerManager --> McpHub : manages
     TheaMcpManager --> McpHub : uses
@@ -145,14 +145,14 @@ src/services/mcp/
 │   └── SseClientFactory.ts    # Factory for SSE clients
 ├── config/                    # Configuration
 │   └── SseTransportConfig.ts  # SSE transport configuration
-├── EmbeddedMcpServer.ts       # MCP server implementation
+├── EmbeddedMcpProvider.ts       # MCP server implementation
 ├── McpConverters.ts           # Format conversion utilities
 ├── McpHub.ts                  # Central hub for MCP instances
 ├── McpIntegration.ts          # Facade for the MCP system
 ├── McpServerManager.ts        # Server lifecycle management
 ├── McpToolRegistry.ts         # Tool registry
 ├── McpToolRouter.ts           # Request routing
-└── UnifiedMcpToolSystem.ts    # Tool system management
+└── McpToolExecutor.ts    # Tool system management
 ```
 
 ## Proposed Architecture
@@ -364,12 +364,12 @@ classDiagram
 src/services/mcp/
 ├── core/                           # Core MCP functionality
 │   ├── McpToolRegistry.ts          # Tool registration and management
-│   ├── McpToolExecutor.ts          # (renamed from UnifiedMcpToolSystem)
+│   ├── McpToolExecutor.ts          # (renamed from McpToolExecutor)
 │   ├── McpToolRouter.ts            # Format detection and routing
 │   └── McpConverters.ts            # Format conversion utilities
 │
 ├── providers/                      # MCP server implementations
-│   ├── EmbeddedMcpProvider.ts      # (renamed from EmbeddedMcpServer)
+│   ├── EmbeddedMcpProvider.ts      # (renamed from EmbeddedMcpProvider)
 │   ├── RemoteMcpProvider.ts        # For connecting to external MCP servers
 │   └── MockMcpProvider.ts          # For testing
 │
@@ -410,13 +410,13 @@ src/services/mcp/
   - Import types from new types directory
   - No functional changes needed
 
-#### 2. McpToolExecutor.ts (renamed from UnifiedMcpToolSystem.ts)
-- **Source**: `src/services/mcp/UnifiedMcpToolSystem.ts`
+#### 2. McpToolExecutor.ts (renamed from McpToolExecutor.ts)
+- **Source**: `src/services/mcp/McpToolExecutor.ts`
 - **Destination**: `src/services/mcp/core/McpToolExecutor.ts`
 - **Changes**:
-  - Rename class from `UnifiedMcpToolSystem` to `McpToolExecutor`
+  - Rename class from `McpToolExecutor` to `McpToolExecutor`
   - Update imports to reflect new file structure
-  - Update references to `EmbeddedMcpServer` to use `EmbeddedMcpProvider`
+  - Update references to `EmbeddedMcpProvider` to use `EmbeddedMcpProvider`
   - Move type definitions to `types/McpToolTypes.ts`
   - Update all references to this class in other files
 
@@ -425,7 +425,7 @@ src/services/mcp/
 - **Destination**: `src/services/mcp/core/McpToolRouter.ts`
 - **Changes**:
   - Update imports to reflect new file structure
-  - Update references to `UnifiedMcpToolSystem` to use `McpToolExecutor`
+  - Update references to `McpToolExecutor` to use `McpToolExecutor`
   - Move type definitions to `types/McpToolTypes.ts`
 
 #### 4. McpConverters.ts
@@ -438,11 +438,11 @@ src/services/mcp/
 
 ### Provider Components
 
-#### 5. EmbeddedMcpProvider.ts (renamed from EmbeddedMcpServer.ts)
-- **Source**: `src/services/mcp/EmbeddedMcpServer.ts`
+#### 5. EmbeddedMcpProvider.ts (renamed from EmbeddedMcpProvider.ts)
+- **Source**: `src/services/mcp/EmbeddedMcpProvider.ts`
 - **Destination**: `src/services/mcp/providers/EmbeddedMcpProvider.ts`
 - **Changes**:
-  - Rename class from `EmbeddedMcpServer` to `EmbeddedMcpProvider`
+  - Rename class from `EmbeddedMcpProvider` to `EmbeddedMcpProvider`
   - Update imports to reflect new file structure
   - Move type definitions to `types/McpProviderTypes.ts`
   - Extract transport-specific code to `transport/SseTransport.ts` and `transport/StdioTransport.ts`
@@ -452,7 +452,7 @@ src/services/mcp/
 - **Source**: New file
 - **Destination**: `src/services/mcp/providers/MockMcpProvider.ts`
 - **Implementation**:
-  - Extract mock implementations from `EmbeddedMcpServer.ts`
+  - Extract mock implementations from `EmbeddedMcpProvider.ts`
   - Create a proper mock provider for testing
   - Implement the same interface as `EmbeddedMcpProvider`
 
@@ -511,8 +511,8 @@ src/services/mcp/
 - **Destination**: `src/services/mcp/integration/McpIntegration.ts`
 - **Changes**:
   - Update imports to reflect new file structure
-  - Update references to `UnifiedMcpToolSystem` to use `McpToolExecutor`
-  - Update references to `EmbeddedMcpServer` to use `EmbeddedMcpProvider`
+  - Update references to `McpToolExecutor` to use `McpToolExecutor`
+  - Update references to `EmbeddedMcpProvider` to use `EmbeddedMcpProvider`
 
 #### 14. ProviderIntegration.ts
 - **Source**: New file
@@ -552,7 +552,7 @@ src/services/mcp/
 - **Source**: New file
 - **Destination**: `src/services/mcp/types/McpToolTypes.ts`
 - **Implementation**:
-  - Extract tool-related types from `UnifiedMcpToolSystem.ts` and `McpToolRouter.ts`
+  - Extract tool-related types from `McpToolExecutor.ts` and `McpToolRouter.ts`
   - Define interfaces for tool-related operations
 
 #### 19. McpTransportTypes.ts
@@ -566,7 +566,7 @@ src/services/mcp/
 - **Source**: New file
 - **Destination**: `src/services/mcp/types/McpProviderTypes.ts`
 - **Implementation**:
-  - Extract provider-related types from `EmbeddedMcpServer.ts`
+  - Extract provider-related types from `EmbeddedMcpProvider.ts`
   - Define interfaces for provider-related operations
 
 ## Implementation Strategy
@@ -600,12 +600,12 @@ flowchart TD
 
 ### Phase 3: Migrate Core Components
 1. Migrate `McpToolRegistry.ts` to the core directory
-2. Rename and migrate `UnifiedMcpToolSystem.ts` to `McpToolExecutor.ts`
+2. Rename and migrate `McpToolExecutor.ts` to `McpToolExecutor.ts`
 3. Migrate `McpToolRouter.ts` to the core directory
 4. Migrate `McpConverters.ts` to the core directory
 
 ### Phase 4: Migrate Provider Components
-1. Rename and migrate `EmbeddedMcpServer.ts` to `EmbeddedMcpProvider.ts`
+1. Rename and migrate `EmbeddedMcpProvider.ts` to `EmbeddedMcpProvider.ts`
 2. Create `MockMcpProvider.ts`
 3. Create `RemoteMcpProvider.ts`
 
@@ -694,11 +694,11 @@ gantt
     Create Type Definitions              :a2, after a1, 2d
     section Core Components
     Migrate McpToolRegistry              :b1, after a2, 1d
-    Migrate UnifiedMcpToolSystem         :b2, after b1, 2d
+    Migrate McpToolExecutor         :b2, after b1, 2d
     Migrate McpToolRouter                :b3, after b2, 1d
     Migrate McpConverters                :b4, after b3, 1d
     section Provider Components
-    Migrate EmbeddedMcpServer            :c1, after b4, 2d
+    Migrate EmbeddedMcpProvider            :c1, after b4, 2d
     Create MockMcpProvider               :c2, after c1, 1d
     Create RemoteMcpProvider             :c3, after c2, 2d
     section Transport Components

--- a/cline_docs/architectural_notes/tool_use/mcp/ollama_openai_mcp_integration.md
+++ b/cline_docs/architectural_notes/tool_use/mcp/ollama_openai_mcp_integration.md
@@ -18,8 +18,8 @@ graph TD
     B -- "routes through" --> D[McpIntegration]
     C -- "routes through" --> D
     D -- "routes to" --> E[McpToolRouter]
-    E -- "executes via" --> F[UnifiedMcpToolSystem]
-    F -- "executes on" --> G[EmbeddedMcpServer]
+    E -- "executes via" --> F[McpToolExecutor]
+    F -- "executes on" --> G[EmbeddedMcpProvider]
 ```
 
 ### 2.2 Key Components
@@ -34,9 +34,9 @@ graph TD
 
 5. **McpToolRouter**: Routes tool use requests to the appropriate handler based on their format.
 
-6. **UnifiedMcpToolSystem**: Provides a unified interface for tool use across different AI models.
+6. **McpToolExecutor**: Provides a unified interface for tool use across different AI models.
 
-7. **EmbeddedMcpServer**: Executes tool use requests and returns results.
+7. **EmbeddedMcpProvider**: Executes tool use requests and returns results.
 
 ## 3. Tool Use Processing Flow
 
@@ -47,8 +47,8 @@ sequenceDiagram
     participant OAH as OpenAiHandler
     participant MCP as McpIntegration
     participant Router as McpToolRouter
-    participant System as UnifiedMcpToolSystem
-    participant Server as EmbeddedMcpServer
+    participant System as McpToolExecutor
+    participant Server as EmbeddedMcpProvider
 
     Model->>OH: Stream with tool use
     
@@ -90,8 +90,8 @@ sequenceDiagram
    b. It calls the `processToolUse` method inherited from BaseProvider.
    c. The `processToolUse` method routes the tool call through McpIntegration's `routeToolUse` method.
    d. McpIntegration detects the format and routes to the appropriate handler in McpToolRouter.
-   e. McpToolRouter converts the tool call to a neutral format and executes it via UnifiedMcpToolSystem.
-   f. UnifiedMcpToolSystem executes the tool on the EmbeddedMcpServer.
+   e. McpToolRouter converts the tool call to a neutral format and executes it via McpToolExecutor.
+   f. McpToolExecutor executes the tool on the EmbeddedMcpProvider.
    g. The result is returned back through the chain.
    h. The Ollama handler yields the tool result to the model.
 

--- a/cline_docs/architectural_notes/tool_use/mcp/openai_function_format_integration.md
+++ b/cline_docs/architectural_notes/tool_use/mcp/openai_function_format_integration.md
@@ -21,8 +21,8 @@ graph TD
     A[BaseProvider] --> B[Provider Handlers]
     B -- "registers" --> C[McpIntegration]
     C -- "registers with" --> D[McpToolRegistry]
-    C -- "registers with" --> E[UnifiedMcpToolSystem]
-    E -- "registers with" --> F[EmbeddedMcpServer]
+    C -- "registers with" --> E[McpToolExecutor]
+    E -- "registers with" --> F[EmbeddedMcpProvider]
     G[McpConverters] -- "converts to" --> H[OpenAI Function Format]
     B -- "uses" --> G
     I[OllamaHandler] -- "includes functions in" --> J[Model Prompt]
@@ -52,8 +52,8 @@ sequenceDiagram
     participant OAH as OpenAiHandler
     participant MCP as McpIntegration
     participant Router as McpToolRouter
-    participant System as UnifiedMcpToolSystem
-    participant Server as EmbeddedMcpServer
+    participant System as McpToolExecutor
+    participant Server as EmbeddedMcpProvider
     
     Model->>OH: Stream with function call
     OH->>OAH: extractToolCalls(delta)
@@ -118,12 +118,12 @@ public getToolRegistry(): McpToolRegistry {
 }
 ```
 
-### 3.3 Update UnifiedMcpToolSystem to Expose Tool Registry
+### 3.3 Update McpToolExecutor to Expose Tool Registry
 
-The `UnifiedMcpToolSystem` class should be updated to expose the tool registry:
+The `McpToolExecutor` class should be updated to expose the tool registry:
 
 ```typescript
-// src/services/mcp/UnifiedMcpToolSystem.ts
+// src/services/mcp/McpToolExecutor.ts
 
 /**
  * Get the tool registry

--- a/cline_docs/architectural_notes/tool_use/mcp/provider_mcp_integration.md
+++ b/cline_docs/architectural_notes/tool_use/mcp/provider_mcp_integration.md
@@ -335,8 +335,8 @@ sequenceDiagram
     participant BP as BaseProvider
     participant MI as McpIntegration
     participant MTR as McpToolRouter
-    participant UMTS as UnifiedMcpToolSystem
-    participant EMCP as EmbeddedMcpServer
+    participant UMTS as McpToolExecutor
+    participant EMCP as EmbeddedMcpProvider
     
     PH->>PSH: Detect tool use in model response
     PSH->>BP: processToolUse(toolUseObj)

--- a/cline_docs/architectural_notes/tool_use/mcp/provider_mcp_integration_summary.md
+++ b/cline_docs/architectural_notes/tool_use/mcp/provider_mcp_integration_summary.md
@@ -31,7 +31,7 @@ flowchart TD
     subgraph "MCP Integration"
         MI[McpIntegration]
         MTR[McpToolRouter]
-        UMTS[UnifiedMcpToolSystem]
+        UMTS[McpToolExecutor]
     end
     
     BP --> MI

--- a/cline_docs/architectural_notes/tool_use/ollama_openai_integration_plan.md
+++ b/cline_docs/architectural_notes/tool_use/ollama_openai_integration_plan.md
@@ -18,8 +18,8 @@ graph TD
     B -- "routes through" --> D[McpIntegration]
     C -- "routes through" --> D
     D -- "routes to" --> E[McpToolRouter]
-    E -- "executes via" --> F[UnifiedMcpToolSystem]
-    F -- "executes on" --> G[EmbeddedMcpServer]
+    E -- "executes via" --> F[McpToolExecutor]
+    F -- "executes on" --> G[EmbeddedMcpProvider]
     
     classDef base fill:#f9f,stroke:#333,stroke-width:2px;
     classDef handler fill:#bbf,stroke:#333,stroke-width:2px;
@@ -39,8 +39,8 @@ sequenceDiagram
     participant OAH as OpenAiHandler
     participant MCP as McpIntegration
     participant Router as McpToolRouter
-    participant System as UnifiedMcpToolSystem
-    participant Server as EmbeddedMcpServer
+    participant System as McpToolExecutor
+    participant Server as EmbeddedMcpProvider
 
     Model->>OH: Stream with tool use
     

--- a/cline_docs/plan/05_testing_validation.md
+++ b/cline_docs/plan/05_testing_validation.md
@@ -23,9 +23,9 @@
 **Details:**
 *   **Scope:** All files within `src/services/mcp/` (core, providers, transport, client, integration, management, types) and relevant API handlers in `src/api/providers/`.
 *   **Actions:**
-    1.  **Update Existing Tests:** Locate existing Jest tests (`__tests__` directories) for components that were moved or renamed (e.g., `UnifiedMcpToolSystem` -> `McpToolExecutor`, `EmbeddedMcpServer` -> `EmbeddedMcpProvider`). Update file paths, import statements, class names, and method calls to match the refactored code.
+    1.  **Update Existing Tests:** Locate existing Jest tests (`__tests__` directories) for components that were moved or renamed (e.g., `McpToolExecutor` -> `McpToolExecutor`, `EmbeddedMcpProvider` -> `EmbeddedMcpProvider`). Update file paths, import statements, class names, and method calls to match the refactored code.
     2.  **Create New Tests:** Write new Jest unit tests for all newly created components:
-        *   `core/McpToolExecutor.ts` (if significantly changed from `UnifiedMcpToolSystem`)
+        *   `core/McpToolExecutor.ts` (if significantly changed from `McpToolExecutor`)
         *   `providers/MockMcpProvider.ts`
         *   `providers/RemoteMcpProvider.ts`
         *   `transport/SseTransport.ts`

--- a/cline_docs/plan/archive/01_foundation_core_mcp.md
+++ b/cline_docs/plan/archive/01_foundation_core_mcp.md
@@ -226,13 +226,13 @@
         *   Ensure the singleton pattern (`getInstance`) is correctly implemented.
         *   No major functional changes expected, primarily relocation and import updates.
 
-2.  **Migrate and Rename `UnifiedMcpToolSystem.ts` to `McpToolExecutor.ts`:**
-    *   **Source:** `src/services/mcp/UnifiedMcpToolSystem.ts`
+2.  **Migrate and Rename `McpToolExecutor.ts` to `McpToolExecutor.ts`:**
+    *   **Source:** `src/services/mcp/McpToolExecutor.ts`
     *   **Destination:** `src/services/mcp/core/McpToolExecutor.ts`
     *   **Changes:**
-        *   Rename the class from `UnifiedMcpToolSystem` to `McpToolExecutor`.
+        *   Rename the class from `McpToolExecutor` to `McpToolExecutor`.
         *   Update internal imports for types (from `../types/`) and other components (e.g., `../providers/EmbeddedMcpProvider`, `../core/McpToolRegistry`).
-        *   **Crucially:** Update references to `EmbeddedMcpServer` to use the *new* name `EmbeddedMcpProvider` (this provider will be refactored in Phase 2, but update the reference here).
+        *   **Crucially:** Update references to `EmbeddedMcpProvider` to use the *new* name `EmbeddedMcpProvider` (this provider will be refactored in Phase 2, but update the reference here).
         *   Update the constructor and `getInstance` method (if using singleton) to reflect the new class name.
         *   Review methods like `executeToolFromNeutralFormat` to ensure they interact correctly with the (future refactored) `EmbeddedMcpProvider`.
         *   Remove any format conversion logic that should now reside solely in `McpConverters`.
@@ -242,7 +242,7 @@
     *   **Destination:** `src/services/mcp/core/McpToolRouter.ts`
     *   **Changes:**
         *   Update internal imports for types (from `../types/`) and other components (e.g., `../core/McpToolExecutor`, `../core/McpConverters`).
-        *   Update references to `UnifiedMcpToolSystem` to use the *new* name `McpToolExecutor`.
+        *   Update references to `McpToolExecutor` to use the *new* name `McpToolExecutor`.
         *   Ensure methods like `routeToolUse`, `convertToMcp`, `convertFromMcp` correctly reference `McpConverters` and `McpToolExecutor`.
 
 4.  **Migrate `McpConverters.ts`:**
@@ -253,7 +253,7 @@
         *   Ensure all format conversion logic (XML<->MCP, JSON<->MCP, OpenAI<->MCP, ToolDef->OpenAI Func) resides here.
         *   Verify method signatures match the plan in `mcp_refactoring_implementation_details.md`.
 
-5.  **Update References:** After moving/renaming, search the codebase (especially within `src/services/mcp/`) for old paths or class names (`UnifiedMcpToolSystem`) and update them to point to the new locations and names (`McpToolExecutor`).
+5.  **Update References:** After moving/renaming, search the codebase (especially within `src/services/mcp/`) for old paths or class names (`McpToolExecutor`) and update them to point to the new locations and names (`McpToolExecutor`).
 
 **Verification:**
 *   Confirm the four core component files exist in `src/services/mcp/core/`.

--- a/cline_docs/plan/archive/02_provider_transport.md
+++ b/cline_docs/plan/archive/02_provider_transport.md
@@ -20,11 +20,11 @@
 
 **Details:**
 
-1.  **Migrate and Rename `EmbeddedMcpServer.ts` to `providers/EmbeddedMcpProvider.ts`:**
-    *   **Source:** `src/services/mcp/EmbeddedMcpServer.ts`
+1.  **Migrate and Rename `EmbeddedMcpProvider.ts` to `providers/EmbeddedMcpProvider.ts`:**
+    *   **Source:** `src/services/mcp/EmbeddedMcpProvider.ts`
     *   **Destination:** `src/services/mcp/providers/EmbeddedMcpProvider.ts`
     *   **Changes:**
-        *   Rename the class from `EmbeddedMcpServer` to `EmbeddedMcpProvider`.
+        *   Rename the class from `EmbeddedMcpProvider` to `EmbeddedMcpProvider`.
         *   Implement the `IMcpProvider` interface defined in `../types/McpProviderTypes.ts`.
         *   Update internal imports for types (`../types/`) and core components (`../core/`).
         *   **Crucially:** Remove all transport-specific logic (SSE and Stdio setup, connection handling, port management). This logic will move to the dedicated transport classes (Task 2.2).
@@ -37,7 +37,7 @@
     *   **Destination:** `src/services/mcp/providers/MockMcpProvider.ts`
     *   **Implementation:**
         *   Create a new class `MockMcpProvider` implementing `IMcpProvider`.
-        *   Extract the mock server logic previously embedded within `EmbeddedMcpServer.ts` (or `mcp_refactoring_implementation_details.md`).
+        *   Extract the mock server logic previously embedded within `EmbeddedMcpProvider.ts` (or `mcp_refactoring_implementation_details.md`).
         *   Implement the `IMcpProvider` methods (`start`, `stop`, `registerToolDefinition`, `unregisterTool`, `executeTool`, `getServerUrl`, `isRunning`) with minimal mock behavior suitable for testing components that depend on a provider. It should manage a simple in-memory map of registered tools.
 
 3.  **Create `providers/RemoteMcpProvider.ts`:**
@@ -63,7 +63,7 @@
 
 ## Task 2.2: Implement Transport Components
 
-**Objective:** Create dedicated classes for handling SSE and Stdio transport mechanisms, extracting logic from the old `EmbeddedMcpServer`.
+**Objective:** Create dedicated classes for handling SSE and Stdio transport mechanisms, extracting logic from the old `EmbeddedMcpProvider`.
 
 **Details:**
 
@@ -80,7 +80,7 @@
         *   Create a class `SseTransport` implementing `IMcpTransport` (from `../types/McpTransportTypes.ts`).
         *   Import `SseTransportConfig` from `./config/SseTransportConfig.ts`.
         *   The constructor should accept `SseTransportConfig`.
-        *   Encapsulate the logic for creating, starting, and managing an SSE server using `@modelcontextprotocol/sdk/server/sse.js` (or its mock equivalent). This includes setting up the HTTP server, handling `/events` and `/api` paths, CORS configuration, etc. This logic is extracted from the old `EmbeddedMcpServer.ts` and `sse_transport_implementation_plan.md`.
+        *   Encapsulate the logic for creating, starting, and managing an SSE server using `@modelcontextprotocol/sdk/server/sse.js` (or its mock equivalent). This includes setting up the HTTP server, handling `/events` and `/api` paths, CORS configuration, etc. This logic is extracted from the old `EmbeddedMcpProvider.ts` and `sse_transport_implementation_plan.md`.
         *   Implement `start()`: Initialize and start the underlying SSE server.
         *   Implement `close()`: Properly shut down the underlying SSE server and release the port.
         *   Implement `getPort()`: Return the actual port the server is listening on.
@@ -92,7 +92,7 @@
         *   Create a class `StdioTransport` implementing `IMcpTransport`.
         *   Import `StdioTransportConfig` from `../types/McpTransportTypes.ts`.
         *   The constructor should accept `StdioTransportConfig`.
-        *   Encapsulate the logic for creating and managing a Stdio transport using `@modelcontextprotocol/sdk/server/stdio.js` (or its mock equivalent). This includes spawning the child process and managing stdin/stdout/stderr. This logic might need to be inferred or adapted if not explicitly present in the old `EmbeddedMcpServer`.
+        *   Encapsulate the logic for creating and managing a Stdio transport using `@modelcontextprotocol/sdk/server/stdio.js` (or its mock equivalent). This includes spawning the child process and managing stdin/stdout/stderr. This logic might need to be inferred or adapted if not explicitly present in the old `EmbeddedMcpProvider`.
         *   Implement `start()`: Start the underlying Stdio transport/process.
         *   Implement `close()`: Properly terminate the underlying process and close streams.
         *   Implement `getPort()`: This might return `undefined` or `0` as Stdio doesn't use network ports.


### PR DESCRIPTION
## Summary
- replace mentions of `UnifiedMcpToolSystem` with `McpToolExecutor`
- replace mentions of `EmbeddedMcpServer` with `EmbeddedMcpProvider`
- update mermaid diagrams accordingly

## Testing
- `npm test` *(fails: Cannot find module '../../dist/thea-config')*