### PR TITLE
Organize plan docs

### DIFF
--- a/cline_docs/plan/README.md
+++ b/cline_docs/plan/README.md
@@ -16,17 +16,17 @@ As of May 19, 2025:
 
 Current active plan files:
 
-1.  `04_handler_updates_features.md`: Updating specific API handlers and integrating features like OpenAI function format (partially implemented).
-2.  `05_testing_validation.md`: Comprehensive testing strategy and tasks.
-3.  `06_documentation.md`: Documentation update tasks.
-4.  `mcp_audit_checklist.md`: Tracks the overall implementation progress.
+1.  [04_handler_updates_features.md](./04_handler_updates_features.md): Updating specific API handlers and integrating features like OpenAI function format (partially implemented).
+2.  [05_testing_validation.md](./05_testing_validation.md): Comprehensive testing strategy and tasks.
+3.  [06_documentation.md](./06_documentation.md): Documentation update tasks.
+4.  [mcp_audit_checklist.md](./mcp_audit_checklist.md): Tracks the overall implementation progress.
 
 ### Archive
 
-Completed plan documents are stored in the `archive/` directory:
+Completed plan documents are stored in the [`archive/`](./archive/) directory:
 
-1.  `01_foundation_core_mcp.md`: Setting up the structure and refactoring core MCP components.
-2.  `02_provider_transport.md`: Refactoring MCP providers and implementing transport layers.
-3.  `03_integration_client.md`: Refactoring integration layers and client components.
+1.  [01_foundation_core_mcp.md](./archive/01_foundation_core_mcp.md): Setting up the structure and refactoring core MCP components.
+2.  [02_provider_transport.md](./archive/02_provider_transport.md): Refactoring MCP providers and implementing transport layers.
+3.  [03_integration_client.md](./archive/03_integration_client.md): Refactoring integration layers and client components.
 
 Refer to the specific files for detailed sub-tasks, file paths, code references, and relevant architectural context.


### PR DESCRIPTION
## Summary
- update MCP implementation plan README with links to archived phases

## Testing
- `npx prettier -w cline_docs/plan/README.md`
- `npm run test:types` *(fails: Cannot find module '../../../dist/thea-config')*