### PR TITLE
Fix lint issues in MCP transport modules

### DIFF
--- a/src/services/mcp/providers/MockMcpProvider.ts
+++ b/src/services/mcp/providers/MockMcpProvider.ts
@@ -17,7 +17,7 @@ export class MockMcpProvider extends EventEmitter implements IMcpProvider {
     super();
   }
 
-  async start(): Promise<void> {
+  start(): void {
     if (this.isStarted) {
       return;
     }
@@ -26,7 +26,7 @@ export class MockMcpProvider extends EventEmitter implements IMcpProvider {
     this.emit("started", { url: this.serverUrl.toString() });
   }
 
-  async stop(): Promise<void> {
+  stop(): void {
     if (!this.isStarted) {
       return;
     }

--- a/src/services/mcp/providers/RemoteMcpProvider.ts
+++ b/src/services/mcp/providers/RemoteMcpProvider.ts
@@ -5,6 +5,7 @@ import {
   IMcpProvider,
 } from "../types/McpProviderTypes";
 import { SseClientFactory } from "../client/SseClientFactory";
+import { McpClient } from "../client/McpClient";
 
 /**
  * RemoteMcpProvider provides a provider for connecting to external MCP servers.
@@ -13,7 +14,7 @@ export class RemoteMcpProvider extends EventEmitter implements IMcpProvider {
   private tools: Map<string, ToolDefinition> = new Map();
   private isStarted = false;
   private serverUrl?: URL;
-  private client?: any;
+  private client?: McpClient;
 
   constructor(private readonly url: URL) {
     super();
@@ -68,7 +69,8 @@ export class RemoteMcpProvider extends EventEmitter implements IMcpProvider {
       throw new Error("Remote MCP provider not started");
     }
     try {
-      const result = await this.client.callTool({ name, arguments: args });
+      interface ToolCallResponse { content: Array<{ type: string; text?: string }>; status?: string }
+      const result = await this.client.callTool({ name, arguments: args }) as ToolCallResponse;
       return { content: result.content, isError: result.status === "error" };
     } catch (error) {
       return {

--- a/src/services/mcp/transport/SseTransport.ts
+++ b/src/services/mcp/transport/SseTransport.ts
@@ -5,20 +5,31 @@ import { SseTransportConfig, DEFAULT_SSE_CONFIG } from "./config/SseTransportCon
  * SseTransport provides an implementation of the MCP transport using SSE.
  * Requires the @modelcontextprotocol/sdk package to be installed.
  */
+interface SSEServerTransportLike {
+  close(): Promise<void>;
+  getPort(): number;
+  onerror?: (error: Error) => void;
+  onclose?: () => void;
+}
+
 export class SseTransport implements IMcpTransport {
-  private transport: any;
-  private config: SseTransportConfig;
+  private transport?: SSEServerTransportLike;
+  private readonly config: SseTransportConfig;
 
   constructor(config?: SseTransportConfig) {
     this.config = { ...DEFAULT_SSE_CONFIG, ...config };
+  }
 
+  private async initTransport(): Promise<void> {
+    if (this.transport) {
+      return;
+    }
     try {
-      const sdk = require("@modelcontextprotocol/sdk/dist/cjs/server/sse.js");
-      if (!sdk || !sdk.SSEServerTransport) {
-        throw new Error("MCP SDK SSEServerTransport not found");
-      }
-      
-      this.transport = new sdk.SSEServerTransport({
+      const { SSEServerTransport } = (await import("@modelcontextprotocol/sdk/dist/cjs/server/sse.js")) as {
+        SSEServerTransport: new (opts: SseTransportConfig) => SSEServerTransportLike;
+      };
+      const Transport = SSEServerTransport;
+      this.transport = new Transport({
         port: this.config.port,
         hostname: this.config.hostname,
         cors: this.config.allowExternalConnections ? { origin: "*" } : { origin: "localhost" },
@@ -33,8 +44,7 @@ export class SseTransport implements IMcpTransport {
   }
 
   async start(): Promise<void> {
-    // SSE transport does not require explicit start
-    return Promise.resolve();
+    await this.initTransport();
   }
 
   async close(): Promise<void> {
@@ -44,7 +54,9 @@ export class SseTransport implements IMcpTransport {
   }
 
   getPort(): number {
-    // Get the port from the SDK transport
+    if (!this.transport) {
+      throw new Error("Transport not initialized");
+    }
     if (!this.transport.getPort) {
       throw new Error("MCP SDK transport does not implement getPort()");
     }

--- a/src/services/mcp/transport/StdioTransport.ts
+++ b/src/services/mcp/transport/StdioTransport.ts
@@ -6,14 +6,13 @@ import { StdioTransportConfig } from "../types/McpTransportTypes";
  * This will be replaced with the actual implementation when the MCP SDK is installed
  */
 class MockStdioServerTransport {
-  constructor() {}
   start(): Promise<void> {
     return Promise.resolve();
   }
   close(): Promise<void> {
     return Promise.resolve();
   }
-  get stderr(): any {
+  get stderr(): unknown {
     return undefined;
   }
   onerror?: (error: Error) => void;
@@ -23,18 +22,35 @@ class MockStdioServerTransport {
 /**
  * StdioTransport provides an implementation of the MCP transport using stdio.
  */
+interface StdioServerTransportLike {
+  start(): Promise<void>;
+  close(): Promise<void>;
+  readonly stderr?: unknown;
+  onerror?: (error: Error) => void;
+  onclose?: () => void;
+}
+
 export class StdioTransport implements IMcpTransport {
-  private transport: unknown;
+  private transport?: StdioServerTransportLike;
   private _stderr?: unknown;
+  private readonly options: StdioTransportConfig;
 
   constructor(options: StdioTransportConfig) {
+    this.options = options;
+  }
+
+  private async initTransport(): Promise<void> {
+    if (this.transport) {
+      return;
+    }
     try {
-      const { StdioServerTransport } = require("@modelcontextprotocol/sdk/server/stdio.js");
-      this.transport = new StdioServerTransport({
-        command: options.command,
-        args: options.args,
+      const mod = await import("@modelcontextprotocol/sdk/server/stdio.js");
+      const Transport = mod.StdioServerTransport as new (opts: StdioTransportConfig & { stderr: string }) => StdioServerTransportLike;
+      this.transport = new Transport({
+        command: this.options.command,
+        args: this.options.args,
         env: {
-          ...options.env,
+          ...this.options.env,
           ...(process.env.PATH ? { PATH: process.env.PATH } : {}),
         },
         stderr: "pipe",
@@ -46,15 +62,16 @@ export class StdioTransport implements IMcpTransport {
   }
 
   async start(): Promise<void> {
-    if (this.transport && typeof (this.transport as any).start === "function") {
-      await (this.transport as any).start();
-      this._stderr = (this.transport as any).stderr;
+    await this.initTransport();
+    if (this.transport) {
+      await this.transport.start();
+      this._stderr = this.transport.stderr;
     }
   }
 
   async close(): Promise<void> {
-    if (this.transport && typeof (this.transport as any).close === "function") {
-      await (this.transport as any).close();
+    if (this.transport) {
+      await this.transport.close();
     }
   }
 
@@ -68,13 +85,13 @@ export class StdioTransport implements IMcpTransport {
 
   set onerror(handler: (error: Error) => void) {
     if (this.transport) {
-      (this.transport as any).onerror = handler;
+      this.transport.onerror = handler;
     }
   }
 
   set onclose(handler: () => void) {
     if (this.transport) {
-      (this.transport as any).onclose = handler;
+      this.transport.onclose = handler;
     }
   }
 }

--- a/src/services/mcp/types/McpProviderTypes.ts
+++ b/src/services/mcp/types/McpProviderTypes.ts
@@ -20,7 +20,7 @@ export interface ToolCallResult {
 export interface ToolDefinition {
   name: string;
   description?: string;
-  paramSchema?: Record<string, any>; // JSON Schema for parameters
+  paramSchema?: Record<string, unknown>; // JSON Schema for parameters
   handler: (args: Record<string, unknown>) => Promise<ToolCallResult>;
 }
 

--- a/src/services/mcp/types/McpTransportTypes.ts
+++ b/src/services/mcp/types/McpTransportTypes.ts
@@ -23,7 +23,7 @@ export interface IMcpTransport {
   onclose?: () => void;
   // Add other transport-specific methods/properties if needed
   // For SDK compatibility, the connect method in McpServer might expect a transport with `send`
-  send?: (message: any) => Promise<void>;
+  send?: (message: unknown) => Promise<void>;
 }
 
 // Add StdioTransportConfig if needed


### PR DESCRIPTION
## Summary
- update StdioTransport to lazily import SDK and remove `any`
- clean up RemoteMcpProvider typing and result handling
- simplify MockMcpProvider start/stop methods
- refactor SseTransport to avoid `require` and use typed import
- fix interfaces in MCP provider and transport types

## Testing
- `npx eslint src/services/mcp/types/McpProviderTypes.ts`
- `npx eslint src/services/mcp/types/McpTransportTypes.ts`
- `npx eslint src/services/mcp/transport/StdioTransport.ts`
- `npx eslint src/services/mcp/transport/SseTransport.ts`
- `npx eslint src/services/mcp/providers/RemoteMcpProvider.ts`
- `npx eslint src/services/mcp/providers/MockMcpProvider.ts`
- `nvm exec npm run lint` *(fails: many remaining errors)*
