### PR TITLE
Fix lint issues in checkpoint service tests

### DIFF
--- a/src/services/checkpoints/__mocks__/ShadowCheckpointService.ts
+++ b/src/services/checkpoints/__mocks__/ShadowCheckpointService.ts
@@ -3,22 +3,12 @@ import EventEmitter from "events"
 import { CheckpointStorage } from "../../../shared/checkpoints"
 
 export abstract class ShadowCheckpointService extends EventEmitter {
-	public static getTaskStorage = jest
-		.fn()
-		.mockImplementation(
-			async ({
-				taskId,
-				globalStorageDir,
-				workspaceDir,
-			}: {
-				taskId: string
-				globalStorageDir: string
-				workspaceDir: string
-			}): Promise<CheckpointStorage | undefined> => {
-				// For tests, always return "task" as the storage type
-				return "task"
-			},
-		)
+        public static getTaskStorage = jest
+                .fn()
+                .mockImplementation(
+                        (): Promise<CheckpointStorage | undefined> =>
+                                Promise.resolve("task"),
+                )
 
 	// Use Jest mock functions for these methods
 	public static deleteTask = jest.fn().mockResolvedValue(undefined)


### PR DESCRIPTION
## Summary
- clean up unused constants and strengthen logging in `ShadowCheckpointService`
- simplify mock implementation in test mocks
- type jest handlers in `ShadowCheckpointService.test.ts`
- remove unnecessary assertions and awaits

## Testing
- `nvm exec npm run lint`