### PR TITLE
Fix linter warnings in test suites

### DIFF
--- a/src/integrations/terminal/__tests__/TerminalRegistry.test.ts
+++ b/src/integrations/terminal/__tests__/TerminalRegistry.test.ts
@@ -6,15 +6,15 @@ import { EXTENSION_DISPLAY_NAME } from "../../../../dist/thea-config" // Import 
 // Mock vscode.window.createTerminal
 const mockCreateTerminal = jest.fn()
 jest.mock("vscode", () => ({
-	window: {
-		createTerminal: (...args: any[]) => {
-			mockCreateTerminal(...args)
-			return {
-				exitStatus: undefined,
-			}
-		},
-	},
-	ThemeIcon: jest.fn(),
+        window: {
+                createTerminal: (...args: unknown[]) => {
+                        mockCreateTerminal(...args)
+                        return {
+                                exitStatus: undefined,
+                        }
+                },
+        },
+        ThemeIcon: jest.fn(),
 }))
 
 describe("TerminalRegistry", () => {
@@ -28,8 +28,8 @@ describe("TerminalRegistry", () => {
 
 			expect(mockCreateTerminal).toHaveBeenCalledWith({
 				cwd: "/test/path",
-				name: EXTENSION_DISPLAY_NAME,
-				iconPath: expect.any(Object),
+                                name: EXTENSION_DISPLAY_NAME as string,
+                                iconPath: expect.any(Object) as unknown,
 				env: {
 					PAGER: "cat",
 					PROMPT_COMMAND: "sleep 0.050",


### PR DESCRIPTION
## Summary
- clean up unused mocks in terminal exit code tests and type errors
- fix `TerminalRegistry` test mocks
- tighten typings in `WorkspaceTracker` tests

## Testing
- `npx eslint src/integrations/terminal/__tests__/TerminalProcessInterpretExitCode.test.ts`
- `npx eslint src/integrations/terminal/__tests__/TerminalRegistry.test.ts`
- `npx eslint src/integrations/workspace/__tests__/WorkspaceTracker.test.ts`
- `nvm exec npm run lint` *(fails: 1110 errors remaining but not in changed files)*