### PR TITLE
Fix linter issues in terminal modules

### DIFF
--- a/src/integrations/misc/line-counter.ts
+++ b/src/integrations/misc/line-counter.ts
@@ -12,8 +12,8 @@ export async function countFileLines(filePath: string): Promise<number> {
 	// Check if file exists
 	try {
 		await fs.promises.access(filePath, fs.constants.F_OK)
-	} catch (error) {
-		throw new Error(`File not found: ${filePath}`)
+        } catch {
+                throw new Error(`File not found: ${filePath}`)
 	}
 
 	return new Promise((resolve, reject) => {
@@ -33,12 +33,12 @@ export async function countFileLines(filePath: string): Promise<number> {
 			resolve(lineCount)
 		})
 
-		rl.on("error", (err) => {
-			reject(err)
-		})
+                rl.on("error", (err) => {
+                        reject(err instanceof Error ? err : new Error(String(err)))
+                })
 
-		readStream.on("error", (err) => {
-			reject(err)
-		})
+                readStream.on("error", (err) => {
+                        reject(err instanceof Error ? err : new Error(String(err)))
+                })
 	})
 }

--- a/src/integrations/terminal/Terminal.ts
+++ b/src/integrations/terminal/Terminal.ts
@@ -180,9 +180,9 @@ export class Terminal {
 
 			// Wait for shell integration before executing the command
 			pWaitFor(() => this.terminal.shellIntegration !== undefined, { timeout: Terminal.shellIntegrationTimeout })
-				.then(() => {
-					process.run(command)
-				})
+                                .then(() => {
+                                        void process.run(command)
+                                })
 				.catch(() => {
 					console.log(`[Terminal ${this.id}] Shell integration not available. Command execution aborted.`)
 					process.emit(

--- a/src/integrations/terminal/TerminalProcess.ts
+++ b/src/integrations/terminal/TerminalProcess.ts
@@ -296,9 +296,13 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 			let stream: AsyncIterable<string>
 			try {
 				stream = await streamAvailable
-			} catch (error) {
-				// Stream timeout or other error occurred
-				console.error("[Terminal Process] Stream error:", error.message)
+                        } catch (error) {
+                                // Stream timeout or other error occurred
+                                if (error instanceof Error) {
+                                        console.error("[Terminal Process] Stream error:", error.message)
+                                } else {
+                                        console.error("[Terminal Process] Stream error", error)
+                                }
 
 				// Emit completed event with error message
 				this.emit(
@@ -396,8 +400,8 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 			}
 
 			// Wait for shell execution to complete and handle exit details
-			const exitDetails = await shellExecutionComplete
-			this.isHot = false
+                        await shellExecutionComplete
+                        this.isHot = false
 
 			if (commandOutputStarted) {
 				// Emit any remaining output before completing
@@ -672,15 +676,15 @@ export type TerminalProcessResultPromise = TerminalProcess & Promise<void>
 
 // Similar to execa's ResultPromise, this lets us create a mixin of both a TerminalProcess and a Promise: https://github.com/sindresorhus/execa/blob/main/lib/methods/promise.js
 export function mergePromise(process: TerminalProcess, promise: Promise<void>): TerminalProcessResultPromise {
-	const nativePromisePrototype = (async () => {})().constructor.prototype
-	const descriptors = ["then", "catch", "finally"].map(
-		(property) => [property, Reflect.getOwnPropertyDescriptor(nativePromisePrototype, property)] as const,
-	)
-	for (const [property, descriptor] of descriptors) {
-		if (descriptor) {
-			const value = descriptor.value.bind(promise)
-			Reflect.defineProperty(process, property, { ...descriptor, value })
-		}
-	}
-	return process as TerminalProcessResultPromise
+        const nativePromisePrototype = Object.getPrototypeOf(Promise.resolve()) as Record<string, unknown>
+        const descriptors = (['then', 'catch', 'finally'] as const).map(
+                (property) => [property, Object.getOwnPropertyDescriptor(nativePromisePrototype, property)] as const,
+        )
+        for (const [property, descriptor] of descriptors) {
+                if (descriptor?.value && typeof descriptor.value === 'function') {
+                        const value = (descriptor.value as (...args: unknown[]) => unknown).bind(promise)
+                        Reflect.defineProperty(process, property, { ...descriptor, value })
+                }
+        }
+        return process as TerminalProcessResultPromise
 }


### PR DESCRIPTION
## Summary
- resolve linter warnings from the bottom of the lint output
- harden error handling in `TerminalProcess`
- mark asynchronous command run in `Terminal`
- improve `line-counter` error handling

## Testing
- `nvm exec npm run lint` *(fails: 1191 problems)*