### PR TITLE
Fix linter issues in editor and i18n files

### DIFF
--- a/src/i18n/setup.ts
+++ b/src/i18n/setup.ts
@@ -1,45 +1,33 @@
 import i18next from "i18next"
+import fs from "node:fs"
+import path from "node:path"
 
 // Build translations object
-const translations: Record<string, Record<string, any>> = {}
+const translations: Record<string, Record<string, unknown>> = {}
 
 // Determine if running in test environment (jest)
 const isTestEnv = process.env.NODE_ENV === "test" || process.env.JEST_WORKER_ID !== undefined
 
-// Detect environment - browser vs Node.js
-const isBrowser = typeof window !== "undefined" && typeof window.document !== "undefined"
-
-// Define interface for VSCode extension process
-interface VSCodeProcess extends NodeJS.Process {
-	resourcesPath?: string
-}
-
-// Type cast process to custom interface with resourcesPath
-const vscodeProcess = process as VSCodeProcess
-
 // Load translations based on environment
 if (!isTestEnv) {
-	try {
-		// Dynamic imports to avoid browser compatibility issues
-		const fs = require("fs")
-		const path = require("path")
+        try {
 
 		const localesDir = path.join(__dirname, "i18n", "locales")
 
-		try {
-			// Find all language directories
-			const languageDirs = fs.readdirSync(localesDir, { withFileTypes: true })
+                try {
+                        // Find all language directories
+                        const languageDirs = fs.readdirSync(localesDir, { withFileTypes: true })
 
-			const languages = languageDirs
-				.filter((dirent: { isDirectory: () => boolean }) => dirent.isDirectory())
-				.map((dirent: { name: string }) => dirent.name)
+                        const languages = languageDirs
+                                .filter((dirent: fs.Dirent) => dirent.isDirectory())
+                                .map((dirent: fs.Dirent) => dirent.name)
 
-			// Process each language
-			languages.forEach((language: string) => {
-				const langPath = path.join(localesDir, language)
+                        // Process each language
+                        languages.forEach((language: string) => {
+                                const langPath = path.join(localesDir, language)
 
 				// Find all JSON files in the language directory
-				const files = fs.readdirSync(langPath).filter((file: string) => file.endsWith(".json"))
+                                const files = fs.readdirSync(langPath).filter((file: string) => file.endsWith(".json"))
 
 				// Initialize language in translations object
 				if (!translations[language]) {
@@ -47,9 +35,9 @@ if (!isTestEnv) {
 				}
 
 				// Process each namespace file
-				files.forEach((file: string) => {
-					const namespace = path.basename(file, ".json")
-					const filePath = path.join(langPath, file)
+                                files.forEach((file: string) => {
+                                        const namespace = path.basename(file, ".json")
+                                        const filePath = path.join(langPath, file)
 
 					try {
 						// Read and parse the JSON file
@@ -71,7 +59,7 @@ if (!isTestEnv) {
 }
 
 // Initialize i18next with configuration
-i18next.init({
+void i18next.init({
 	lng: "en",
 	fallbackLng: "en",
 	debug: false,

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -246,7 +246,7 @@ export class DiffViewProvider {
 		}
 
 		// edit is done
-		await this.reset()
+                this.reset()
 	}
 
 	private async closeAllDiffViews() {
@@ -352,7 +352,7 @@ export class DiffViewProvider {
 	}
 
 	// close editor if open?
-	async reset() {
+        reset() {
 		this.editType = undefined
 		this.isEditing = false
 		this.originalContent = undefined

--- a/src/integrations/editor/__tests__/DiffViewProvider.test.ts
+++ b/src/integrations/editor/__tests__/DiffViewProvider.test.ts
@@ -45,8 +45,8 @@ describe("DiffViewProvider", () => {
 
 		diffViewProvider = new DiffViewProvider(mockCwd)
 		// Mock the necessary properties and methods
-		;(diffViewProvider as any).relPath = "test.txt"
-		;(diffViewProvider as any).activeDiffEditor = {
+                ;(diffViewProvider as unknown as { relPath: string }).relPath = "test.txt"
+                ;(diffViewProvider as unknown as { activeDiffEditor: vscode.TextEditor }).activeDiffEditor = {
 			document: {
 				uri: { fsPath: `${mockCwd}/test.txt` },
 				getText: jest.fn(),
@@ -59,13 +59,13 @@ describe("DiffViewProvider", () => {
 			edit: jest.fn().mockResolvedValue(true),
 			revealRange: jest.fn(),
 		}
-		;(diffViewProvider as any).activeLineController = { setActiveLine: jest.fn(), clear: jest.fn() }
-		;(diffViewProvider as any).fadedOverlayController = { updateOverlayAfterLine: jest.fn(), clear: jest.fn() }
+                ;(diffViewProvider as unknown as { activeLineController: { setActiveLine: jest.Mock; clear: jest.Mock } }).activeLineController = { setActiveLine: jest.fn(), clear: jest.fn() }
+                ;(diffViewProvider as unknown as { fadedOverlayController: { updateOverlayAfterLine: jest.Mock; clear: jest.Mock } }).fadedOverlayController = { updateOverlayAfterLine: jest.fn(), clear: jest.fn() }
 	})
 
 	describe("update method", () => {
 		it("should preserve empty last line when original content has one", async () => {
-			;(diffViewProvider as any).originalContent = "Original content\n"
+                        ;(diffViewProvider as unknown as { originalContent: string }).originalContent = "Original content\n"
 			await diffViewProvider.update("New content", true)
 
 			expect(mockWorkspaceEdit.replace).toHaveBeenCalledWith(
@@ -76,7 +76,7 @@ describe("DiffViewProvider", () => {
 		})
 
 		it("should not add extra newline when accumulated content already ends with one", async () => {
-			;(diffViewProvider as any).originalContent = "Original content\n"
+                        ;(diffViewProvider as unknown as { originalContent: string }).originalContent = "Original content\n"
 			await diffViewProvider.update("New content\n", true)
 
 			expect(mockWorkspaceEdit.replace).toHaveBeenCalledWith(
@@ -87,7 +87,7 @@ describe("DiffViewProvider", () => {
 		})
 
 		it("should not add newline when original content does not end with one", async () => {
-			;(diffViewProvider as any).originalContent = "Original content"
+                        ;(diffViewProvider as unknown as { originalContent: string }).originalContent = "Original content"
 			await diffViewProvider.update("New content", true)
 
 			expect(mockWorkspaceEdit.replace).toHaveBeenCalledWith(expect.anything(), expect.anything(), "New content")


### PR DESCRIPTION
## Summary
- resolve eslint warnings in `DiffViewProvider.reset`
- clean up the i18n setup script
- avoid `any` in `DiffViewProvider` tests

## Testing
- `npx eslint src/i18n/setup.ts src/integrations/editor/DiffViewProvider.ts src/integrations/editor/__tests__/DiffViewProvider.test.ts`