### PR TITLE
Add parseAssistantMessage test

### DIFF
--- a/MASTER_TEST_CHECKLIST.md
+++ b/MASTER_TEST_CHECKLIST.md
@@ -3,7 +3,7 @@
 Generated with scripts/generate-master-list.ts
 
 - [x] function: accessMcpResourceTool (src/core/tools/accessMcpResourceTool.ts)
-- [ ] interface: AccessMcpResourceToolUse (src/core/assistant-message/index.ts)
+- [x] interface: AccessMcpResourceToolUse (src/core/assistant-message/index.ts)
 - [x] function: activate (src/extension.ts)
 - [x] function: addCustomInstructions (src/core/prompts/sections/custom-instructions.ts)
 - [x] function: addLineNumbers (src/integrations/misc/extract-text.ts)

--- a/src/core/__tests__/parse-assistant-message.test.ts
+++ b/src/core/__tests__/parse-assistant-message.test.ts
@@ -1,0 +1,21 @@
+import { parseAssistantMessage } from "../assistant-message/parse-assistant-message";
+import type { AccessMcpResourceToolUse } from "../assistant-message";
+
+describe("parseAssistantMessage - access_mcp_resource", () => {
+  it("parses access_mcp_resource tool use", () => {
+    const msg =
+      "Hello <access_mcp_resource><server_name>srv</server_name><uri>/path</uri></access_mcp_resource> World";
+    const result = parseAssistantMessage(msg);
+
+    expect(result).toEqual([
+      { type: "text", content: "Hello", partial: false },
+      {
+        type: "tool_use",
+        name: "access_mcp_resource",
+        params: { server_name: "srv", uri: "/path" },
+        partial: false,
+      } as AccessMcpResourceToolUse,
+      { type: "text", content: "World", partial: false },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- cover `parseAssistantMessage` for the access MCP resource tool
- mark `AccessMcpResourceToolUse` as tested in checklist

## Testing
- `npm test` *(fails: 211 passing, 20 failing)*

------
https://chatgpt.com/codex/tasks/task_e_6840c5ad94a88333a2206dc95df725a2