### PR TITLE
Fix askFollowupQuestionTool test imports

### DIFF
--- a/src/core/tools/__tests__/askFollowupQuestionTool.test.ts
+++ b/src/core/tools/__tests__/askFollowupQuestionTool.test.ts
@@ -5,9 +5,9 @@ import { askFollowupQuestionTool } from "../askFollowupQuestionTool"
 import { TheaTask } from "../../TheaTask"
 import type { ToolUse } from "../../assistant-message"
 import { AskApproval, HandleError, PushToolResult, RemoveClosingTag } from "../types"
-import { formatResponse } from "../prompts/responses"
+import { formatResponse } from "../../prompts/responses"
 
-jest.mock("../prompts/responses")
+jest.mock("../../prompts/responses")
 
 describe("askFollowupQuestionTool", () => {
     let mockTheaTask: jest.Mocked<Partial<TheaTask>> & {


### PR DESCRIPTION
## Summary
- fix incorrect relative path in askFollowupQuestionTool tests

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68419b88b7a88333867d52e627a5536f