### PR TITLE
Fix startServer to use EmbeddedMcpProvider.create

### DIFF
--- a/test/mcp-mock-server/server.ts
+++ b/test/mcp-mock-server/server.ts
@@ -3,7 +3,7 @@ import { EmbeddedMcpProvider } from '../../src/services/mcp/providers/EmbeddedMc
 let provider: EmbeddedMcpProvider | null = null;
 
 export const startServer = async (): Promise<void> => {
-  provider = new EmbeddedMcpProvider({ port: 0, hostname: 'localhost' });
+  provider = await EmbeddedMcpProvider.create({ port: 0, hostname: 'localhost' });
   await provider.start();
   const url = provider.getServerUrl();
   if (url) {


### PR DESCRIPTION
## Summary
- fix the mock MCP server startup to use the async `EmbeddedMcpProvider.create`

## Testing
- `npm test` *(fails: could not complete linting/tests in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6841a2267060833382686792d711de7f