### PR TITLE
Fix mock server startup

### DIFF
--- a/src/services/mcp/providers/EmbeddedMcpProvider.ts
+++ b/src/services/mcp/providers/EmbeddedMcpProvider.ts
@@ -39,8 +39,9 @@ export class EmbeddedMcpProvider extends EventEmitter implements IMcpProvider {
 
   private static async createServerInstance(): Promise<SdkMcpServer> {
     try {
-      // Correctly import McpServer from the SDK's CJS distribution
-      const mod = (await import("@modelcontextprotocol/sdk/dist/cjs/server/mcp.js")) as {
+      // Import McpServer using the package export which resolves to the
+      // appropriate module format (ESM or CJS) based on the current runtime.
+      const mod = (await import("@modelcontextprotocol/sdk/server/mcp.js")) as {
         McpServer?: new (options: { name: string; version: string }) => SdkMcpServer;
       };
       const { McpServer } = mod;

--- a/src/services/mcp/transport/SseTransport.ts
+++ b/src/services/mcp/transport/SseTransport.ts
@@ -1,19 +1,24 @@
 import { IMcpTransport } from "../types/McpTransportTypes";
 import { SseTransportConfig, DEFAULT_SSE_CONFIG } from "./config/SseTransportConfig";
+import express from "express";
+import http, { AddressInfo } from "http";
 
 /**
  * SseTransport provides an implementation of the MCP transport using SSE.
  * Requires the @modelcontextprotocol/sdk package to be installed.
  */
-interface SSEServerTransportLike {
+interface StreamableHTTPServerTransportLike {
+  start(): Promise<void>;
   close(): Promise<void>;
-  getPort(): number;
   onerror?: (error: Error) => void;
   onclose?: () => void;
+  handleRequest(req: express.Request, res: express.Response, body?: unknown): Promise<void>;
 }
 
 export class SseTransport implements IMcpTransport {
-  private transport?: SSEServerTransportLike;
+  private transport?: StreamableHTTPServerTransportLike;
+  public httpServer?: http.Server;
+  public port?: number;
   private readonly config: SseTransportConfig;
 
   constructor(config?: SseTransportConfig) {
@@ -25,17 +30,28 @@ export class SseTransport implements IMcpTransport {
       return;
     }
     try {
-      const { SSEServerTransport } = (await import("@modelcontextprotocol/sdk/dist/cjs/server/sse.js")) as {
-        SSEServerTransport: new (opts: SseTransportConfig) => SSEServerTransportLike;
+      const { StreamableHTTPServerTransport } = (await import(
+        "@modelcontextprotocol/sdk/server/streamableHttp.js"
+      )) as {
+        StreamableHTTPServerTransport: new (opts: Record<string, unknown>) => StreamableHTTPServerTransportLike;
       };
-      const Transport = SSEServerTransport;
-      this.transport = new Transport({
-        port: this.config.port,
-        hostname: this.config.hostname,
-        cors: this.config.allowExternalConnections ? { origin: "*" } : { origin: "localhost" },
-        eventsPath: this.config.eventsPath,
-        apiPath: this.config.apiPath,
+
+      this.transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+      const app = express();
+      app.use(express.json());
+      app.all(this.config.eventsPath!, async (req, res) => {
+        await this.transport!.handleRequest(req, res, req.body);
       });
+      app.all(this.config.apiPath!, async (req, res) => {
+        await this.transport!.handleRequest(req, res, req.body);
+      });
+
+      await new Promise<void>((resolve) => {
+        this.httpServer = app.listen(this.config.port, this.config.hostname, () => resolve());
+      });
+      await this.transport.start();
+      const address = this.httpServer.address() as AddressInfo;
+      this.port = address.port;
     } catch (error) {
       const msg = `Failed to initialize MCP SDK: ${error instanceof Error ? error.message : String(error)}`;
       console.error(msg);
@@ -51,22 +67,18 @@ export class SseTransport implements IMcpTransport {
     if (this.transport?.close) {
       await this.transport.close();
     }
+    if (this.httpServer) {
+      await new Promise<void>((resolve) => this.httpServer!.close(() => resolve()));
+      this.httpServer = undefined;
+      this.port = undefined;
+    }
   }
 
   getPort(): number {
-    if (!this.transport) {
-      throw new Error("Transport not initialized");
+    if (!this.httpServer || typeof this.port !== 'number') {
+      throw new Error("Server not started");
     }
-    if (!this.transport.getPort) {
-      throw new Error("MCP SDK transport does not implement getPort()");
-    }
-
-    const port = this.transport.getPort();
-    if (typeof port !== 'number' || port === 0) {
-      throw new Error(`Invalid port returned from MCP SDK: ${port}`);
-    }
-
-    return port;
+    return this.port;
   }
 
   public set onerror(handler: (error: Error) => void) {


### PR DESCRIPTION
## Summary
- fix EmbeddedMcpProvider server import path
- create Express-backed SSE transport so the mock MCP server actually starts

## Testing
- `npm test` *(fails: 211 passing, 20 failing)*

------
https://chatgpt.com/codex/tasks/task_e_6841ae5fd7d083338b4ccb7cbf764719