### PR TITLE
Run SSE-enabled MCP tests

### DIFF
--- a/jest.sse.config.js
+++ b/jest.sse.config.js
@@ -1,0 +1,12 @@
+const base = require('./jest.config.js');
+const backendProject = base.projects.find(p => p.displayName === 'backend');
+const sseProject = {
+  ...backendProject,
+  moduleNameMapper: { ...backendProject.moduleNameMapper },
+  globalSetup: base.globalSetup,
+  globalTeardown: base.globalTeardown,
+};
+// remove mocks for @modelcontextprotocol/sdk
+delete sseProject.moduleNameMapper['@modelcontextprotocol/sdk$'];
+delete sseProject.moduleNameMapper['@modelcontextprotocol/sdk/(.*)'];
+module.exports = sseProject;

--- a/test/mcp-mock-server/teardown.ts
+++ b/test/mcp-mock-server/teardown.ts
@@ -1,6 +1,6 @@
 import { stopServer } from './server';
 
-module.exports = async () => {
+export const mcpTeardown = async (): Promise<void> => {
   console.log('\nStopping Mock MCP Server...');
   await stopServer();
   console.log('Mock MCP Server stopped.');

--- a/test/ollama-mock-server/teardown.ts
+++ b/test/ollama-mock-server/teardown.ts
@@ -1,6 +1,6 @@
 import { stopServer } from './server';
 
-module.exports = async () => {
+export const ollamaTeardown = async (): Promise<void> => {
   console.log('\nStopping Mock Ollama Server...');
   await stopServer();
   console.log('Mock Ollama Server stopped.');


### PR DESCRIPTION
## Summary
- fix teardown function exports for mock servers
- adjust OpenAI jest mock to include default export
- add dedicated Jest config without SDK mocks for SSE tests

## Testing
- `npx jest src/services/mcp/__tests__/SseTransport.test.ts --runInBand --config jest.sse.config.js --detectOpenHandles`
- `npx jest src/services/mcp/__tests__/ollama-mcp-integration.test.ts --runInBand --config jest.sse.config.js --detectOpenHandles`


------
https://chatgpt.com/codex/tasks/task_e_6841b8235af88333828b56c1f3c2b164