### PR TITLE
Add OpenAI mock setup for tests

### DIFF
--- a/test/globalSetup.ts
+++ b/test/globalSetup.ts
@@ -1,7 +1,9 @@
 import ollamaSetup from './ollama-mock-server/setup.ts';
 import mcpSetup from './mcp-mock-server/setup.ts';
+import openaiSetup from './openai-mock/setup.ts';
 
 module.exports = async () => {
   await ollamaSetup();
   await mcpSetup();
+  await openaiSetup();
 };

--- a/test/globalTeardown.ts
+++ b/test/globalTeardown.ts
@@ -1,7 +1,9 @@
 import { ollamaTeardown } from './ollama-mock-server/teardown.ts';
 import { mcpTeardown } from './mcp-mock-server/teardown.ts';
+import { openaiTeardown } from './openai-mock/teardown.ts';
 
 module.exports = async () => {
   await mcpTeardown();
   await ollamaTeardown();
+  await openaiTeardown();
 };

--- a/test/openai-mock/setup.ts
+++ b/test/openai-mock/setup.ts
@@ -1,0 +1,9 @@
+import { mockOpenAIResponse } from 'openai-api-mock';
+
+export let openAIMock: ReturnType<typeof mockOpenAIResponse> | null = null;
+
+export default async () => {
+  console.log('\nStarting OpenAI API Mock...');
+  openAIMock = mockOpenAIResponse(true);
+  console.log('OpenAI API Mock started.');
+};

--- a/test/openai-mock/teardown.ts
+++ b/test/openai-mock/teardown.ts
@@ -1,0 +1,9 @@
+import { openAIMock } from './setup.ts';
+
+export const openaiTeardown = async (): Promise<void> => {
+  if (openAIMock) {
+    console.log('\nStopping OpenAI API Mock...');
+    openAIMock.stopMocking();
+    console.log('OpenAI API Mock stopped.');
+  }
+};


### PR DESCRIPTION
## Summary
- add OpenAI API mocking helper under `test/openai-mock`
- register the OpenAI mock in `globalSetup`
- stop the mock in `globalTeardown`

## Testing
- `npm run test:jest` *(fails: 211 passing, 20 failing)*

------
https://chatgpt.com/codex/tasks/task_e_6841bf18fbe08333b808cb4349237a2b