### PR TITLE
Increase test coverage

### DIFF
--- a/src/api/transform/__tests__/vscode-lm-format.test.ts
+++ b/src/api/transform/__tests__/vscode-lm-format.test.ts
@@ -200,3 +200,59 @@ describe("convertToAnthropicRole", () => {
 		expect(result).toBeNull()
 	})
 })
+
+describe("asObjectSafe via convertToVsCodeLmMessages", () => {
+    it("parses JSON strings in tool_use input", () => {
+        const messages: NeutralConversationHistory = [
+            {
+                role: "assistant",
+                content: [
+                    {
+                        type: "tool_use",
+                        id: "1",
+                        name: "test",
+                        input: '{"foo": "bar"}'
+                    }
+                ]
+            }
+        ]
+        const result = convertToVsCodeLmMessages(messages)
+        const toolCall = result[0].content[0] as MockLanguageModelToolCallPart
+        expect(toolCall.input).toEqual({ foo: "bar" })
+    })
+
+    it("handles invalid JSON by returning empty object", () => {
+        const messages: NeutralConversationHistory = [
+            {
+                role: "assistant",
+                content: [
+                    {
+                        type: "tool_use",
+                        id: "2",
+                        name: "test",
+                        input: '{invalid}'
+                    }
+                ]
+            }
+        ]
+        const result = convertToVsCodeLmMessages(messages)
+        const toolCall = result[0].content[0] as MockLanguageModelToolCallPart
+        expect(toolCall.input).toEqual({})
+    })
+
+    it("clones object inputs", () => {
+        const obj = { a: 1 }
+        const messages: NeutralConversationHistory = [
+            {
+                role: "assistant",
+                content: [
+                    { type: "tool_use", id: "3", name: "test", input: obj }
+                ]
+            }
+        ]
+        const result = convertToVsCodeLmMessages(messages)
+        const toolCall = result[0].content[0] as MockLanguageModelToolCallPart
+        expect(toolCall.input).toEqual(obj)
+        expect(toolCall.input).not.toBe(obj)
+    })
+})

--- a/src/core/webview/__tests__/getNonce.test.ts
+++ b/src/core/webview/__tests__/getNonce.test.ts
@@ -1,0 +1,16 @@
+import { getNonce } from "../getNonce"
+
+describe("getNonce", () => {
+    it("generates a 32-character alphanumeric string", () => {
+        const nonce = getNonce()
+        expect(nonce).toMatch(/^[A-Za-z0-9]{32}$/)
+    })
+
+    it("returns a new value for each call", () => {
+        const first = getNonce()
+        const second = getNonce()
+        expect(first).not.toBe(second)
+        expect(first).toMatch(/^[A-Za-z0-9]{32}$/)
+        expect(second).toMatch(/^[A-Za-z0-9]{32}$/)
+    })
+})


### PR DESCRIPTION
## Summary
- add tests for generating a nonce
- cover object parsing via convertToVsCodeLmMessages

## Testing
- `npm test --silent` *(fails: ReferenceError: TERMINAL_SHELL_INTEGRATION_TIMEOUT is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6842bed7ebe883338bc3201b3f0109e1