### PR TITLE
Increase test coverage

### DIFF
--- a/src/api/transform/__tests__/vscode-lm-format.test.ts
+++ b/src/api/transform/__tests__/vscode-lm-format.test.ts
@@ -200,3 +200,59 @@ describe("convertToAnthropicRole", () => {
 		expect(result).toBeNull()
 	})
 })
+
+describe("asObjectSafe via convertToVsCodeLmMessages", () => {
+    it("parses JSON strings in tool_use input", () => {
+        const messages: NeutralConversationHistory = [
+            {
+                role: "assistant",
+                content: [
+                    {
+                        type: "tool_use",
+                        id: "1",
+                        name: "test",
+                        input: '{"foo": "bar"}'
+                    }
+                ]
+            }
+        ]
+        const result = convertToVsCodeLmMessages(messages)
+        const toolCall = result[0].content[0] as MockLanguageModelToolCallPart
+        expect(toolCall.input).toEqual({ foo: "bar" })
+    })
+
+    it("handles invalid JSON by returning empty object", () => {
+        const messages: NeutralConversationHistory = [
+            {
+                role: "assistant",
+                content: [
+                    {
+                        type: "tool_use",
+                        id: "2",
+                        name: "test",
+                        input: '{invalid}'
+                    }
+                ]
+            }
+        ]
+        const result = convertToVsCodeLmMessages(messages)
+        const toolCall = result[0].content[0] as MockLanguageModelToolCallPart
+        expect(toolCall.input).toEqual({})
+    })
+
+    it("clones object inputs", () => {
+        const obj = { a: 1 }
+        const messages: NeutralConversationHistory = [
+            {
+                role: "assistant",
+                content: [
+                    { type: "tool_use", id: "3", name: "test", input: obj }
+                ]
+            }
+        ]
+        const result = convertToVsCodeLmMessages(messages)
+        const toolCall = result[0].content[0] as MockLanguageModelToolCallPart
+        expect(toolCall.input).toEqual(obj)
+        expect(toolCall.input).not.toBe(obj)
+    })
+})

--- a/src/core/webview/__tests__/TheaProvider.test.ts
+++ b/src/core/webview/__tests__/TheaProvider.test.ts
@@ -11,7 +11,7 @@ import { ProviderSettingsManager } from "../../config/ProviderSettingsManager"
 import { CustomModesManager } from "../../config/CustomModesManager"
 import { TheaTask } from "../../TheaTask" // Renamed import
 import { McpServerManager } from "../../../services/mcp/management/McpServerManager"
-import type { defaultModeSlug } from "../../../shared/modes"
+import { defaultModeSlug } from "../../../shared/modes"
 import { HistoryItem } from "../../../shared/HistoryItem"
 import { t } from "../../../i18n"
 

--- a/src/core/webview/__tests__/TheaStateManager.test.ts
+++ b/src/core/webview/__tests__/TheaStateManager.test.ts
@@ -6,10 +6,10 @@ import { TheaStateManager } from "../thea/TheaStateManager" // Renamed import an
 import { ContextProxy } from "../../config/ContextProxy"
 import { ProviderSettingsManager } from "../../config/ProviderSettingsManager"
 import { CustomModesManager } from "../../config/CustomModesManager"
-import type { defaultModeSlug } from "../../../shared/modes"
-import type { experimentDefault } from "../../../shared/experiments"
+import { defaultModeSlug } from "../../../shared/modes"
+import { experimentDefault } from "../../../shared/experiments"
 import { formatLanguage } from "../../../shared/language"
-import type { TERMINAL_SHELL_INTEGRATION_TIMEOUT } from "../../../integrations/terminal/Terminal"
+import { TERMINAL_SHELL_INTEGRATION_TIMEOUT } from "../../../integrations/terminal/Terminal"
 
 // Mock dependencies
 jest.mock("vscode")

--- a/src/core/webview/__tests__/getNonce.test.ts
+++ b/src/core/webview/__tests__/getNonce.test.ts
@@ -1,0 +1,16 @@
+import { getNonce } from "../getNonce"
+
+describe("getNonce", () => {
+    it("generates a 32-character alphanumeric string", () => {
+        const nonce = getNonce()
+        expect(nonce).toMatch(/^[A-Za-z0-9]{32}$/)
+    })
+
+    it("returns a new value for each call", () => {
+        const first = getNonce()
+        const second = getNonce()
+        expect(first).not.toBe(second)
+        expect(first).toMatch(/^[A-Za-z0-9]{32}$/)
+        expect(second).toMatch(/^[A-Za-z0-9]{32}$/)
+    })
+})

--- a/src/core/webview/thea/TheaStateManager.ts
+++ b/src/core/webview/thea/TheaStateManager.ts
@@ -8,8 +8,8 @@ import { GlobalState, TheaCodeSettings } from "../../../schemas"
 import { Mode, ModeConfig, defaultModeSlug } from "../../../shared/modes"
 import { ApiProvider } from "../../../shared/api"
 import { formatLanguage } from "../../../shared/language"
-import type { experimentDefault } from "../../../shared/experiments"
-import type { TERMINAL_SHELL_INTEGRATION_TIMEOUT } from "../../../integrations/terminal/Terminal"
+import { experimentDefault } from "../../../shared/experiments"
+import { TERMINAL_SHELL_INTEGRATION_TIMEOUT } from "../../../integrations/terminal/Terminal"
 
 /**
  * Manages application state retrieval and updates.


### PR DESCRIPTION
## Summary
- add tests for generating a nonce
- cover object parsing via convertToVsCodeLmMessages
- fix runtime constant imports causing ReferenceErrors

## Testing
- `npm test --silent` *(fails: many unit tests fail due to environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_6842bed7ebe883338bc3201b3f0109e1