### PR TITLE
Add more utility tests

### DIFF
--- a/src/shared/__tests__/array.test.ts
+++ b/src/shared/__tests__/array.test.ts
@@ -1,0 +1,32 @@
+// npx jest src/shared/__tests__/array.test.ts
+import { findLastIndex, findLast } from "../array"
+
+describe("array utilities", () => {
+    describe("findLastIndex", () => {
+        it("returns last index matching predicate", () => {
+            const arr = [1, 2, 3, 2]
+            const idx = findLastIndex(arr, x => x === 2)
+            expect(idx).toBe(3)
+        })
+
+        it("returns -1 when no match", () => {
+            const arr = [1, 2, 3]
+            const idx = findLastIndex(arr, x => x === 4)
+            expect(idx).toBe(-1)
+        })
+    })
+
+    describe("findLast", () => {
+        it("returns last element matching predicate", () => {
+            const arr = ["a", "b", "c", "b"]
+            const val = findLast(arr, x => x === "b")
+            expect(val).toBe("b")
+        })
+
+        it("returns undefined when no match", () => {
+            const arr: number[] = []
+            const val = findLast(arr, x => x > 0)
+            expect(val).toBeUndefined()
+        })
+    })
+})

--- a/src/shared/__tests__/doesFileMatchRegex.test.ts
+++ b/src/shared/__tests__/doesFileMatchRegex.test.ts
@@ -1,0 +1,20 @@
+// npx jest src/shared/__tests__/doesFileMatchRegex.test.ts
+import { doesFileMatchRegex } from "../modes"
+
+describe("doesFileMatchRegex", () => {
+    it("returns true when pattern matches", () => {
+        expect(doesFileMatchRegex("src/file.ts", "\\.ts$"))
+            .toBe(true)
+    })
+
+    it("returns false when pattern does not match", () => {
+        expect(doesFileMatchRegex("src/file.ts", "\\.js$")).toBe(false)
+    })
+
+    it("handles invalid regex gracefully", () => {
+        const errSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+        expect(doesFileMatchRegex("src/file.ts", "[")).toBe(false)
+        expect(errSpy).toHaveBeenCalled()
+        errSpy.mockRestore()
+    })
+})

--- a/src/shared/__tests__/formatPath.test.ts
+++ b/src/shared/__tests__/formatPath.test.ts
@@ -1,0 +1,24 @@
+// npx jest src/shared/__tests__/formatPath.test.ts
+import { formatPath } from "../formatPath"
+
+describe("formatPath", () => {
+    it("adds leading backslash on Windows", () => {
+        const result = formatPath("folder/file", "win32")
+        expect(result).toBe("\\folder/file")
+    })
+
+    it("preserves existing leading separator", () => {
+        const result = formatPath("/already", "darwin")
+        expect(result).toBe("/already")
+    })
+
+    it("escapes spaces according to platform", () => {
+        expect(formatPath("my file", "win32")).toBe("\\my/ file")
+        expect(formatPath("my file", "linux")).toBe("/my\\ file")
+    })
+
+    it("can skip space escaping", () => {
+        const result = formatPath("my file", "win32", false)
+        expect(result).toBe("\\my file")
+    })
+})


### PR DESCRIPTION
## Summary
- cover `formatPath` and `doesFileMatchRegex`
- cover `findLastIndex`/`findLast` helpers

## Testing
- `npm test` *(fails: Cannot log after tests are done)*

------
https://chatgpt.com/codex/tasks/task_e_6842ce43aadc833386c6d58c888a2704