### PR TITLE
Fix lint warnings

### DIFF
--- a/src/core/diff/strategies/new-unified/__tests__/search-strategies.test.ts
+++ b/src/core/diff/strategies/new-unified/__tests__/search-strategies.test.ts
@@ -1,15 +1,5 @@
 import { findAnchorMatch, findExactMatch, findSimilarityMatch, findLevenshteinMatch } from "../search-strategies"
 
-type SearchStrategy = (
-	searchStr: string,
-	content: string[],
-	startIndex?: number,
-) => {
-	index: number
-	confidence: number
-	strategy: string
-}
-
 const testCases = [
 	{
 		name: "should return no match if the search string is not found",

--- a/src/core/diff/strategies/new-unified/edit-strategies.ts
+++ b/src/core/diff/strategies/new-unified/edit-strategies.ts
@@ -1,31 +1,11 @@
 import { diff_match_patch } from "diff-match-patch"
 import { EditResult, Hunk } from "./types"
-import { getDMPSimilarity, validateEditResult } from "./search-strategies"
+import { validateEditResult } from "./search-strategies"
 import * as path from "path"
 import simpleGit, { SimpleGit } from "simple-git"
 import * as tmp from "tmp"
 import * as fs from "fs"
 
-// Helper function to infer indentation - simplified version
-function inferIndentation(line: string, contextLines: string[], previousIndent: string = ""): string {
-	// If the line has explicit indentation in the change, use it exactly
-	const lineMatch = line.match(/^(\s+)/)
-	if (lineMatch) {
-		return lineMatch[1]
-	}
-
-	// If we have context lines, use the indentation from the first context line
-	const contextLine = contextLines[0]
-	if (contextLine) {
-		const contextMatch = contextLine.match(/^(\s+)/)
-		if (contextMatch) {
-			return contextMatch[1]
-		}
-	}
-
-	// Fallback to previous indent
-	return previousIndent
-}
 
 // Context matching edit strategy
 export function applyContextMatching(hunk: Hunk, content: string[], matchPosition: number): EditResult {
@@ -201,9 +181,9 @@ export async function applyGitFallback(hunk: Hunk, content: string[]): Promise<E
 					result: newLines,
 					strategy: "git-fallback",
 				}
-			} catch (cherryPickError) {
-				console.error("Strategy 1 failed with merge conflict")
-			}
+                        } catch {
+                                console.error("Strategy 1 failed with merge conflict")
+                        }
 		} catch (error) {
 			console.error("Strategy 1 failed:", error)
 		}
@@ -243,9 +223,9 @@ export async function applyGitFallback(hunk: Hunk, content: string[]): Promise<E
 					result: newLines,
 					strategy: "git-fallback",
 				}
-			} catch (cherryPickError) {
-				console.error("Strategy 2 failed with merge conflict")
-			}
+                        } catch {
+                                console.error("Strategy 2 failed with merge conflict")
+                        }
 		} catch (error) {
 			console.error("Strategy 2 failed:", error)
 		}

--- a/src/core/ignore/TheaIgnoreController.ts
+++ b/src/core/ignore/TheaIgnoreController.ts
@@ -43,17 +43,17 @@ export class TheaIgnoreController {
 		const fileWatcher = vscode.workspace.createFileSystemWatcher(ignorePattern)
 
 		// Watch for changes and updates
-		this.disposables.push(
-			fileWatcher.onDidChange(() => {
-				this.loadTheaIgnore()
-			}),
-			fileWatcher.onDidCreate(() => {
-				this.loadTheaIgnore()
-			}),
-			fileWatcher.onDidDelete(() => {
-				this.loadTheaIgnore()
-			}),
-		)
+               this.disposables.push(
+                       fileWatcher.onDidChange(() => {
+                               void this.loadTheaIgnore()
+                       }),
+                       fileWatcher.onDidCreate(() => {
+                               void this.loadTheaIgnore()
+                       }),
+                       fileWatcher.onDidDelete(() => {
+                               void this.loadTheaIgnore()
+                       }),
+               )
 
 		// Add fileWatcher itself to disposables
 		this.disposables.push(fileWatcher)
@@ -98,11 +98,10 @@ export class TheaIgnoreController {
 
 			// Ignore expects paths to be path.relative()'d
 			return !this.ignoreInstance.ignores(relativePath)
-		} catch (error) {
-			// console.error(`Error validating access for ${filePath}:`, error)
-			// Ignore is designed to work with relative file paths, so will throw error for paths outside cwd. We are allowing access to all files outside cwd.
-			return true
-		}
+               } catch {
+                       // Ignore is designed to work with relative file paths, so will throw error for paths outside cwd. We are allowing access to all files outside cwd.
+                       return true
+               }
 	}
 
 	/**

--- a/src/core/ignore/__mocks__/TheaIgnoreController.ts
+++ b/src/core/ignore/__mocks__/TheaIgnoreController.ts
@@ -3,24 +3,24 @@ export const LOCK_TEXT_SYMBOL = "\u{1F512}"
 export class TheaIgnoreController {
 	theaIgnoreContent: string | undefined = undefined
 
-	constructor(cwd: string) {
-		// No-op constructor
-	}
+       constructor() {
+               // No-op constructor
+       }
 
 	async initialize(): Promise<void> {
 		// No-op initialization
 		return Promise.resolve()
 	}
 
-	validateAccess(filePath: string): boolean {
-		// Default implementation: allow all access
-		return true
-	}
+       validateAccess(): boolean {
+               // Default implementation: allow all access
+               return true
+       }
 
-	validateCommand(command: string): string | undefined {
-		// Default implementation: allow all commands
-		return undefined
-	}
+       validateCommand(): string | undefined {
+               // Default implementation: allow all commands
+               return undefined
+       }
 
 	filterPaths(paths: string[]): string[] {
 		// Default implementation: allow all paths

--- a/src/core/ignore/__tests__/TheaIgnoreController.security.test.ts
+++ b/src/core/ignore/__tests__/TheaIgnoreController.security.test.ts
@@ -4,7 +4,6 @@ import { TheaIgnoreController } from "../TheaIgnoreController"
 import * as path from "path"
 import * as fs from "fs/promises"
 import { fileExistsAtPath } from "../../../utils/fs"
-import * as vscode from "vscode"
 
 // Mock dependencies
 jest.mock("fs/promises")
@@ -21,10 +20,10 @@ jest.mock("vscode", () => {
 				dispose: jest.fn(),
 			})),
 		},
-		RelativePattern: jest.fn().mockImplementation((base, pattern) => ({
-			base,
-			pattern,
-		})),
+               RelativePattern: jest.fn().mockImplementation((base: string, pattern: string) => ({
+                       base,
+                       pattern,
+               })),
 	}
 })
 

--- a/src/core/mentions/index.ts
+++ b/src/core/mentions/index.ts
@@ -67,7 +67,7 @@ export const handleError = (error: Error, message: string): string => {
 }
 
 // File utilities
-export async function getFileOrFolderContent(mentionPath: string, cwd: string, osInfo: string): Promise<string> {
+export async function getFileOrFolderContent(mentionPath: string, cwd: string): Promise<string> {
 	const absPath = path.resolve(cwd, mentionPath)
 
 	try {
@@ -170,7 +170,7 @@ const fileHandler: HandlerConfig = {
 		}
 
 		try {
-			const content = await getFileOrFolderContent(mentionPath, cwd, osInfo)
+               const content = await getFileOrFolderContent(mentionPath, cwd)
 			return wrapContent(content, tag)
 		} catch (error) {
 			return wrapContent(handleError(error, "fetching content"), tag)


### PR DESCRIPTION
## Summary
- clean up unused types and imports
- remove unused arguments in mock controller
- update ignore controller event handlers
- adjust mention utility function

## Testing
- `npm test` *(fails: 284 failing)*

------
https://chatgpt.com/codex/tasks/task_e_6844dd2e6f74833392472ca2f69977f3