### PR TITLE
Fix waitFor timer

### DIFF
--- a/MASTER_TEST_CHECKLIST.md
+++ b/MASTER_TEST_CHECKLIST.md
@@ -493,3 +493,4 @@ Generated with scripts/generate-master-list.ts
 - [x] function: xmlThinkingToJson (src/utils/json-xml-bridge.ts)
 - [x] function: xmlToolResultToJson (src/utils/json-xml-bridge.ts)
 - [x] function: xmlToolUseToJson (src/utils/json-xml-bridge.ts)
+- [ ] function: waitFor (benchmark/src/utils.ts)

--- a/benchmark/src/utils.ts
+++ b/benchmark/src/utils.ts
@@ -27,12 +27,14 @@ export const waitFor = (
 					}
 
 					resolve()
-				} else {
-					setTimeout(check, interval)
-				}
+                                } else {
+                                        setTimeout(() => {
+                                                void check()
+                                        }, interval)
+                                }
 			}
 
-			check()
+                        void check()
 		}),
 		new Promise((_, reject) => {
 			timeoutId = setTimeout(() => {


### PR DESCRIPTION
## Summary
- ensure timer callback handles async check correctly
- track waitFor function in checklist

## Testing
- `node scripts/run-all-linters.js` *(fails: Exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68452c54d1148333b21b6fd3a1edbe89