### PR TITLE
Fix lint for UnboundHandler

### DIFF
--- a/cline_docs/plan/neutral_anthropic_migration_checklist.md
+++ b/cline_docs/plan/neutral_anthropic_migration_checklist.md
@@ -20,6 +20,7 @@ This checklist tracks the remaining work required to remove direct usage of `@an
   - `src/api/providers/vertex.ts`
 - [ ] Update each handler to depend on `NeutralAnthropicClient` for message creation, streaming, and token counting.
 - [ ] Remove leftover Anthropic specific types in these files and rely solely on neutral history structures.
+  - [x] `src/api/providers/unbound.ts` uses `NeutralConversationHistory`.
 
 ## 3. Update Transformation Utilities
 - [x] Audit all files under `src/api/transform/` for Anthropic types.

--- a/src/api/providers/unbound.ts
+++ b/src/api/providers/unbound.ts
@@ -6,6 +6,7 @@ import { convertToOpenAiMessages } from "../transform/openai-format"
 import { ApiStream, ApiStreamUsageChunk } from "../transform/stream"
 import { SingleCompletionHandler } from "../"
 import { BaseProvider } from "./base-provider"
+import type { NeutralConversationHistory } from "../../shared/neutral-history"
 import type { EXTENSION_NAME } from "../../../dist/thea-config" // Import branded constant
 
 interface UnboundUsage extends OpenAI.CompletionUsage {


### PR DESCRIPTION
## Summary
- import `NeutralConversationHistory` in `UnboundHandler`
- note progress in neutral migration checklist

## Testing
- `npm test` *(fails: Error running lint:root)*

------
https://chatgpt.com/codex/tasks/task_e_68455923be8883339c364502bfa17c29