### PR TITLE
Fix lint warnings

### DIFF
--- a/src/core/diff/strategies/__tests__/unified.test.ts
+++ b/src/core/diff/strategies/__tests__/unified.test.ts
@@ -140,7 +140,7 @@ function App() {
 			}
 		})
 
-                it.skip("should successfully apply a diff with multiple hunks", async () => {
+               it.skip("should successfully apply a diff with multiple hunks", () => {
 			const originalContent = `import { readFile, writeFile } from 'fs';
 
 function processFile(path: string) {

--- a/src/core/ignore/__tests__/TheaIgnoreController.test.ts
+++ b/src/core/ignore/__tests__/TheaIgnoreController.test.ts
@@ -116,7 +116,7 @@ describe(`${AI_IDENTITY_NAME}Ignore Controller`, () => {
 		/**
 		 * Tests the file watcher setup
 		 */
-		it(`should set up file watcher for ${GLOBAL_FILENAMES.IGNORE_FILENAME} changes`, async () => {
+               it(`should set up file watcher for ${GLOBAL_FILENAMES.IGNORE_FILENAME} changes`, () => {
 			// Check that watcher was created with correct pattern
 			expect(vscode.workspace.createFileSystemWatcher).toHaveBeenCalledWith(
 				expect.objectContaining({

--- a/src/core/prompts/__tests__/system.test.ts
+++ b/src/core/prompts/__tests__/system.test.ts
@@ -10,7 +10,7 @@ import { MultiSearchReplaceDiffStrategy } from "../../diff/strategies/multi-sear
 
 // Mock the sections
 jest.mock("../sections/modes", () => ({
-	getModesSection: jest.fn().mockImplementation(async () => `====\n\nMODES\n\n- Test modes section`),
+        getModesSection: jest.fn().mockImplementation(() => `====\n\nMODES\n\n- Test modes section`),
 }))
 
 // Mock the custom instructions
@@ -27,12 +27,12 @@ jest.mock("../sections/custom-instructions", () => {
 // Set up default mock implementation
 const { __setMockImplementation } = jest.requireMock("../sections/custom-instructions")
 __setMockImplementation(
-	async (
-		modeCustomInstructions: string,
-		globalCustomInstructions: string,
-		cwd: string,
-		mode: string,
-		options?: { language?: string },
+        (
+                modeCustomInstructions: string,
+                globalCustomInstructions: string,
+                cwd: string,
+                mode: string,
+                options?: { language?: string },
 	) => {
 		const sections = []
 
@@ -120,20 +120,20 @@ const mockContext = {
 
 // Instead of extending McpHub, create a mock that implements just what we need
 const createMockMcpHub = (): McpHub =>
-	({
-		getServers: () => [],
-		getMcpServersPath: async () => "/mock/mcp/path",
-		getMcpSettingsFilePath: async () => "/mock/settings/path",
-		dispose: async () => {},
-		// Add other required public methods with no-op implementations
-		restartConnection: async () => {},
-		readResource: async () => ({ contents: [] }),
-		callTool: async () => ({ content: [] }),
-		toggleServerDisabled: async () => {},
-		toggleToolAlwaysAllow: async () => {},
-		isConnecting: false,
-		connections: [],
-	}) as unknown as McpHub
+        ({
+                getServers: () => [],
+                getMcpServersPath: () => "/mock/mcp/path",
+                getMcpSettingsFilePath: () => "/mock/settings/path",
+                dispose: () => {},
+                // Add other required public methods with no-op implementations
+                restartConnection: () => {},
+                readResource: () => ({ contents: [] }),
+                callTool: () => ({ content: [] }),
+                toggleServerDisabled: () => {},
+                toggleToolAlwaysAllow: () => {},
+                isConnecting: false,
+                connections: [],
+        }) as unknown as McpHub
 
 describe("SYSTEM_PROMPT", () => {
 	let mockMcpHub: McpHub

--- a/src/core/prompts/instructions/create-mode.ts
+++ b/src/core/prompts/instructions/create-mode.ts
@@ -1,10 +1,9 @@
 import * as path from "path"
 import * as vscode from "vscode"
-import { promises as fs } from "fs"
 import { GlobalFileNames } from "../../../shared/globalFileNames" // Re-add original import
 import { GLOBAL_FILENAMES as BRANDED_FILENAMES, AI_IDENTITY_NAME } from "../../../../dist/thea-config" // Alias branded import
 
-export async function createModeInstructions(context: vscode.ExtensionContext | undefined): Promise<string> {
+export function createModeInstructions(context: vscode.ExtensionContext | undefined): string {
 	if (!context) throw new Error("Missing VSCode Extension Context")
 
 	const settingsDir = path.join(context.globalStorageUri.fsPath, "settings")

--- a/src/core/prompts/sections/mcp-servers.ts
+++ b/src/core/prompts/sections/mcp-servers.ts
@@ -1,11 +1,11 @@
 import { DiffStrategy } from "../../diff/DiffStrategy"
 import { McpHub } from "../../../services/mcp/management/McpHub"
 
-export async function getMcpServersSection(
-	mcpHub?: McpHub,
-	diffStrategy?: DiffStrategy,
-	enableMcpServerCreation?: boolean,
-): Promise<string> {
+export function getMcpServersSection(
+        mcpHub?: McpHub,
+        diffStrategy?: DiffStrategy,
+        enableMcpServerCreation?: boolean,
+): string {
 	if (!mcpHub) {
 		return ""
 	}

--- a/src/core/webview/__tests__/TheaApiManager.test.ts
+++ b/src/core/webview/__tests__/TheaApiManager.test.ts
@@ -82,7 +82,7 @@ describe("ClineApiManager", () => {
 	test("updateApiConfiguration updates mode config association", async () => {
 		// Setup
 		const mockApiConfig = { apiProvider: "openrouter" as const }
-		mockContextProxy.getValue.mockImplementation(async (key) => {
+                mockContextProxy.getValue.mockImplementation((key) => {
 			if (key === "mode") return "code"
 			if (key === "currentApiConfigName") return "test-config"
 			return undefined
@@ -126,7 +126,7 @@ describe("ClineApiManager", () => {
 		mockProviderSettingsManager.listConfig.mockResolvedValue([
 			{ name: "current-config", id: "current-id", apiProvider: "anthropic" },
 		])
-		mockContextProxy.getValue.mockImplementation(async () => "current-config")
+                mockContextProxy.getValue.mockImplementation(() => "current-config")
 		mockProviderSettingsManager.loadConfig.mockResolvedValue(mockApiConfig)
 
 		// Execute

--- a/src/core/webview/__tests__/TheaCacheManager.test.ts
+++ b/src/core/webview/__tests__/TheaCacheManager.test.ts
@@ -11,10 +11,10 @@ jest.mock("fs/promises")
 jest.mock("../../../utils/fs")
 jest.mock("../../../shared/storagePathManager", () => {
 	return {
-		getCacheDirectoryPath: jest.fn().mockImplementation(async (storagePath) => {
+                getCacheDirectoryPath: jest.fn().mockImplementation((storagePath) => {
 			return path.join(storagePath, "cache")
 		}),
-		getSettingsDirectoryPath: jest.fn().mockImplementation(async (storagePath) => {
+                getSettingsDirectoryPath: jest.fn().mockImplementation((storagePath) => {
 			return path.join(storagePath, "settings")
 		}),
 	}


### PR DESCRIPTION
## Summary
- fix require-await lint errors
- prune unused imports
- regenerate test checklist
- revert to old checklist update

## Testing
- `npm test` *(fails: lint and jest issues)*

------
https://chatgpt.com/codex/tasks/task_e_68460217cdd48333bc5a9a30d755f1ed