### PR TITLE
Fix lint warnings

### DIFF
--- a/src/core/prompts/__tests__/sections.test.ts
+++ b/src/core/prompts/__tests__/sections.test.ts
@@ -32,13 +32,16 @@ describe("addCustomInstructions", () => {
 describe("getCapabilitiesSection", () => {
 	const cwd = "/test/path"
 	const mcpHub = undefined
-	const mockDiffStrategy: DiffStrategy = {
-		getName: () => "MockStrategy",
-		getToolDescription: () => "apply_diff tool description",
-		applyDiff: (_originalContent: string, _diffContent: string): Promise<DiffResult> => {
-			return Promise.resolve({ success: true, content: "mock result" })
-		},
-	}
+        const mockDiffStrategy: DiffStrategy = {
+                getName: () => "MockStrategy",
+                getToolDescription: () => "apply_diff tool description",
+                applyDiff: (_originalContent: string, _diffContent: string): Promise<DiffResult> => {
+                        // mark parameters as used to satisfy linting rules
+                        void _originalContent
+                        void _diffContent
+                        return Promise.resolve({ success: true, content: "mock result" })
+                },
+        }
 
 	test("includes apply_diff in capabilities when diffStrategy is provided", () => {
 		const result = getCapabilitiesSection(cwd, false, mcpHub, mockDiffStrategy)

--- a/src/core/prompts/__tests__/system.test.ts
+++ b/src/core/prompts/__tests__/system.test.ts
@@ -15,13 +15,14 @@ jest.mock("../sections/modes", () => ({
 
 // Mock the custom instructions
 jest.mock("../sections/custom-instructions", () => {
-	const addCustomInstructions = jest.fn()
-	return {
-		addCustomInstructions,
-		__setMockImplementation: (impl: any) => {
-			addCustomInstructions.mockImplementation(impl)
-		},
-	}
+        const addCustomInstructions = jest.fn()
+        return {
+                addCustomInstructions,
+                __setMockImplementation: (impl: (...args: unknown[]) => unknown) => {
+                        // Cast is safe in test context
+                        addCustomInstructions.mockImplementation(impl as any)
+                },
+        }
 })
 
 // Set up default mock implementation
@@ -641,22 +642,18 @@ describe("SYSTEM_PROMPT", () => {
 })
 
 describe("addCustomInstructions", () => {
-	let experiments: Record<string, boolean> | undefined
-	beforeAll(() => {
-		// Ensure fs mock is properly initialized
-		const mockFs = jest.requireMock("fs/promises")
-		mockFs._setInitialMockData()
-		mockFs.mkdir.mockImplementation(async (path: string) => {
-			if (path.startsWith("/test")) {
-				mockFs._mockDirectories.add(path)
-				return Promise.resolve()
-			}
-			throw new Error(`ENOENT: no such file or directory, mkdir '${path}'`)
-		})
-
-		// Initialize experiments as undefined by default
-		experiments = undefined
-	})
+        beforeAll(() => {
+                // Ensure fs mock is properly initialized
+                const mockFs = jest.requireMock("fs/promises")
+                mockFs._setInitialMockData()
+                mockFs.mkdir.mockImplementation(async (path: string) => {
+                        if (path.startsWith("/test")) {
+                                mockFs._mockDirectories.add(path)
+                                return Promise.resolve()
+                        }
+                        throw new Error(`ENOENT: no such file or directory, mkdir '${path}'`)
+                })
+        })
 
 	beforeEach(() => {
 		jest.clearAllMocks()

--- a/src/core/prompts/sections/system-info.ts
+++ b/src/core/prompts/sections/system-info.ts
@@ -1,14 +1,12 @@
-import defaultShell from "default-shell"
 import os from "os"
 import osName from "os-name"
-import { Mode, ModeConfig, getModeBySlug, defaultModeSlug, isToolAllowedForMode } from "../../../shared/modes"
+import { Mode, ModeConfig } from "../../../shared/modes"
 import { getShell } from "../../../utils/shell"
 
 export function getSystemInfoSection(cwd: string, currentMode: Mode, customModes?: ModeConfig[]): string {
-	const findModeBySlug = (slug: string, modes?: ModeConfig[]) => modes?.find((m) => m.slug === slug)
-
-	const currentModeName = findModeBySlug(currentMode, customModes)?.name || currentMode
-	const codeModeName = findModeBySlug(defaultModeSlug, customModes)?.name || "Code"
+        // mark parameters as used to satisfy lint rules
+        void currentMode
+        void customModes
 
 	let details = `====
 


### PR DESCRIPTION
## Summary
- fix lint issues in sections tests
- clean up unused imports and params in system info section
- remove unused `experiments` var

## Testing
- `npm test` *(fails: Cannot log after tests are done)*

------
https://chatgpt.com/codex/tasks/task_e_68461089efe48333b009bfd1be0038a2